### PR TITLE
feat(react): add react usage tree mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.0-dev.1 (2026-03-15)
+
+### Features
+
+* bootstrap the project and implement core functionality ([#2](https://github.com/async3619/foresthouse/issues/2)) ([6e3c42e](https://github.com/async3619/foresthouse/commit/6e3c42e34d484345de8c52897fab05197950e971))
+
 # Changelog
 
 All notable changes to this project will be documented in this file by `semantic-release`.

--- a/package.json
+++ b/package.json
@@ -57,19 +57,20 @@
   "author": "Sophia (Turner) <me@sophia-dev.io>",
   "license": "MIT",
   "dependencies": {
+    "oxc-parser": "0.119.0",
     "typescript": "5.9.3"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.7",
     "@commitlint/cli": "20.4.4",
     "@commitlint/config-conventional": "20.4.4",
-    "@types/node": "24.6.2",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/commit-analyzer": "13.0.1",
     "@semantic-release/git": "10.0.1",
     "@semantic-release/github": "12.0.6",
     "@semantic-release/npm": "13.1.5",
     "@semantic-release/release-notes-generator": "14.1.0",
+    "@types/node": "24.6.2",
     "conventional-changelog-conventionalcommits": "9.3.0",
     "husky": "9.1.7",
     "semantic-release": "25.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foresthouse",
-  "version": "0.0.0",
+  "version": "1.0.0-dev.1",
   "description": "A Node.js CLI that reads JavaScript and TypeScript entry files and prints an import tree.",
   "type": "module",
   "packageManager": "pnpm@10.32.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      oxc-parser:
+        specifier: 0.119.0
+        version: 0.119.0
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -475,12 +478,142 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
+  '@oxc-parser/binding-android-arm-eabi@0.119.0':
+    resolution: {integrity: sha512-e0ii/Tqwk5pAHZRY+ZyXOdKHNRNmE+dvTGQZ7xQ5XPH2Am59aktD30QvfcfwItGhNTLCj/5TYGH5RHvmvqaILQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.119.0':
+    resolution: {integrity: sha512-ha0xQpiStuoBv7HGazNKQWa6IRxri2+PpeojdAyBGnHGzfioA1GcStNGEGOyXvF+OxDfWvPuw5QiRYRUMtmgbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.119.0':
+    resolution: {integrity: sha512-h/AIi5jfQz9WQUJJkkkHeXNYMhPtR72qnYZt0ZpM/LvlH/wpI5QkCPi7MWjjyY+m0JDorIXJyfOfccn8SbNSxQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.119.0':
+    resolution: {integrity: sha512-15RwS/AawrgognvWsonI2eLKI5BqO0FzrpYXnzROysSR0x5RYsCc3UMFBwB1ph0UFFQzJy3ZbHHxfxp8RGr5Xg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.119.0':
+    resolution: {integrity: sha512-iKaayTIDqEj0yyNPL+0t/spNAxMv7O32uY4eu/ir8BvFNgavoRmN8uqxRj8sxQDle89N/1Iw0dgRjS3tiWrqlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.119.0':
+    resolution: {integrity: sha512-PDoOaOx8YWoxy19WNeMs6kOE0uFSb5EtA64Ye0wSp6sQpe+l8Gd+yjX2L+yNwd5MpDOvOy8KToa2bqCV4pf6iQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.119.0':
+    resolution: {integrity: sha512-AVxZ5Eo5squsUhpjnkCYuH20t5FCGV3HAP9UOKLxJQkmZW3kJvBGbfpH75ABxRrE2kGqmJW5FmS980u8v9Cepw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.119.0':
+    resolution: {integrity: sha512-9vfdyT9gczSeSwsEkBHVjigI8SWo3iB9zxEzL+YMBUrN0ftCUkKQr27DaDZK4/cQ80t6KRB+g9sUmT2T2AGnOQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.119.0':
+    resolution: {integrity: sha512-7BOq/tjSrtnp/ihw615uGcxMY3iya2qvVtwm15h2NvBZ6Jje+PC1GSUBOLfqGKJbUr9riSVV//a4iNhHI48Qdw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.119.0':
+    resolution: {integrity: sha512-PQIrLJwoAaNyNSWBF+2SSgv44Jp+xpKVUA+8+PuoMhyBQ6lFSbQdaxewdn11i3heTFMYd2xF339HWax4S6MPVA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.119.0':
+    resolution: {integrity: sha512-spNh4YhT9K+Ya5hr6NmI1MazKSKORD8u5/06hFbzTslLnmmxiGaLqJXhNKIYUH39ne/JD5rkoRkUcOB2/LpC3A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.119.0':
+    resolution: {integrity: sha512-hFoCTRxSJAcrNBYVlgNDDQq6LyJLYyhnJDlPtK/mWrPYS3x5/fUR9jc6wo5VyxKIL/0dDJBBWp19v81q9heU/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.119.0':
+    resolution: {integrity: sha512-bl7jHJZq3W5tYEvKG3yWZTUKTNb0/BtyYSnfMIrQ7t8hajCH4i1g0q+14s0KmQQl1UHxIX/Gx/Ps6e92qJQJmQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.119.0':
+    resolution: {integrity: sha512-m+DE7NhJIEGp4efSJnNfRf3swT25rbZ1FTIihV+pOLTI+k5yNguxvqT338mNu61OVSx0BfpV8QlO2nz43GR/Zg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-musl@0.119.0':
+    resolution: {integrity: sha512-pHhnXZHUfd5pYzFLQfvx1DH2HY+L8DPZeh6SsQrsmoaODm1+j8VPeWLwGSrXQSz5f1kfT/mnzm1iNLVOGIeuaw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-openharmony-arm64@0.119.0':
+    resolution: {integrity: sha512-8Fthv9nOec0hQLX16yjYyYIU+u8ZFuQojdQ3vNgXN+PcqI/bDohGgCATrxO69gLf0IzkyOmKmurXOQCYK8BYpQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.119.0':
+    resolution: {integrity: sha512-KpOU6fLqevFDP6ndkgE4BPoceELM4bOsEsAXjpe+FKYuUyEzHssYPBmxouGpXDQeAeWTBIjosw5yElLMRPuccw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.119.0':
+    resolution: {integrity: sha512-omtTgAKIl6GQ40nG+wAWN8xMJLNtfmTdd0+wMIcrw1shX9y5TntAVIuiay3Du0wvUK9sgMpL07HYNphgHeZS0A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.119.0':
+    resolution: {integrity: sha512-+0kqoCfv4WFP3e4BqcVEtf1moUuG9Zv5lo1aKcw1JakqJo008TGG+C2LnVM4QucGSZVQ/Ii/H5XCvrRbkeLQfA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.119.0':
+    resolution: {integrity: sha512-5kaKmBHD+OQjZzGAQQ9n8jWNvCRxu3MjElAjkCqsS3i2wiN3hqHlOPKwGDydYiB1gKdeYGlTjRYtuF4gBLDSxQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@oxc-project/runtime@0.115.0':
     resolution: {integrity: sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@oxc-project/types@0.115.0':
     resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
+
+  '@oxc-project/types@0.119.0':
+    resolution: {integrity: sha512-9SCGhodOxEicD2kblitu34fGHcpmqgI3beYw/E22ehVLHzccHRFH91NmKt0MhZEaAwLpei6OOA9aB6Vuks9qAg==}
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -1613,6 +1746,10 @@ packages:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
 
+  oxc-parser@0.119.0:
+    resolution: {integrity: sha512-fNiKvO0ZHSUmINQlVY2It+vGbHxCvhpqJi0rZYFFOESoOy3fs5E4erKYGZtB/J1aULkjtY06aWNil4JxMsKXGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   p-each-series@3.0.0:
     resolution: {integrity: sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==}
     engines: {node: '>=12'}
@@ -2646,9 +2783,73 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
+  '@oxc-parser/binding-android-arm-eabi@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.119.0':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.119.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.119.0':
+    optional: true
+
   '@oxc-project/runtime@0.115.0': {}
 
   '@oxc-project/types@0.115.0': {}
+
+  '@oxc-project/types@0.119.0': {}
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -3644,6 +3845,31 @@ snapshots:
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
+
+  oxc-parser@0.119.0:
+    dependencies:
+      '@oxc-project/types': 0.119.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.119.0
+      '@oxc-parser/binding-android-arm64': 0.119.0
+      '@oxc-parser/binding-darwin-arm64': 0.119.0
+      '@oxc-parser/binding-darwin-x64': 0.119.0
+      '@oxc-parser/binding-freebsd-x64': 0.119.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.119.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.119.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.119.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.119.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.119.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.119.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.119.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.119.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.119.0
+      '@oxc-parser/binding-linux-x64-musl': 0.119.0
+      '@oxc-parser/binding-openharmony-arm64': 0.119.0
+      '@oxc-parser/binding-wasm32-wasi': 0.119.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.119.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.119.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.119.0
 
   p-each-series@3.0.0: {}
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,13 @@ import { createRequire } from 'node:module'
 import process from 'node:process'
 
 import { analyzeDependencies, graphToSerializableTree } from './analyzer.js'
+import {
+  analyzeReactUsage,
+  graphToSerializableReactTree,
+} from './react-analyzer.js'
+import { printReactUsageTree } from './react-tree.js'
 import { printDependencyTree } from './tree.js'
+import type { ReactUsageFilter } from './types.js'
 
 const require = createRequire(import.meta.url)
 const { version } = require('../package.json') as { version: string }
@@ -15,11 +21,43 @@ interface CliOptions {
   readonly configPath: string | undefined
   readonly includeExternals: boolean
   readonly json: boolean
+  readonly react: ReactUsageFilter | undefined
 }
 
 function main(): void {
   try {
     const options = parseArgs(process.argv.slice(2))
+
+    if (options.react !== undefined) {
+      const graph = analyzeReactUsage(options.entryFile, {
+        ...(options.cwd === undefined ? {} : { cwd: options.cwd }),
+        ...(options.configPath === undefined
+          ? {}
+          : { configPath: options.configPath }),
+      })
+
+      if (options.json) {
+        process.stdout.write(
+          `${JSON.stringify(
+            graphToSerializableReactTree(graph, {
+              filter: options.react,
+            }),
+            null,
+            2,
+          )}\n`,
+        )
+        return
+      }
+
+      process.stdout.write(
+        `${printReactUsageTree(graph, {
+          cwd: options.cwd ?? graph.cwd,
+          filter: options.react,
+        })}\n`,
+      )
+      return
+    }
+
     const graph = analyzeDependencies(options.entryFile, {
       ...(options.cwd === undefined ? {} : { cwd: options.cwd }),
       ...(options.configPath === undefined
@@ -64,6 +102,7 @@ function parseArgs(argv: string[]): CliOptions {
   let configPath: string | undefined
   let includeExternals = false
   let json = false
+  let react: ReactUsageFilter | undefined
 
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index]
@@ -93,6 +132,21 @@ function parseArgs(argv: string[]): CliOptions {
       continue
     }
 
+    if (argument === '--react') {
+      react = 'all'
+      continue
+    }
+
+    if (argument.startsWith('--react=')) {
+      const value = argument.slice('--react='.length)
+      if (value === 'component' || value === 'hook') {
+        react = value
+        continue
+      }
+
+      throw new Error(`Unknown React mode: ${value}`)
+    }
+
     if (argument.startsWith('-')) {
       throw new Error(`Unknown option: ${argument}`)
     }
@@ -114,6 +168,7 @@ function parseArgs(argv: string[]): CliOptions {
     configPath,
     includeExternals,
     json,
+    react,
   }
 }
 
@@ -140,6 +195,7 @@ Options:
   --cwd <path>               Working directory used for relative paths.
   --config <path>            Explicit tsconfig.json or jsconfig.json path.
   --include-externals        Include packages and Node built-ins in the tree.
+  --react[=component|hook]   Print a React usage tree instead of the import tree.
   --json                     Print the dependency tree as JSON.
   -v, --version              Show the current version.
   -h, --help                 Show this help message.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,24 @@
 export { analyzeDependencies, graphToSerializableTree } from './analyzer.js'
+export {
+  analyzeReactUsage,
+  getReactUsageRoots,
+  graphToSerializableReactTree,
+} from './react-analyzer.js'
+export { printReactUsageTree } from './react-tree.js'
 export { printDependencyTree } from './tree.js'
 export type {
   AnalyzeOptions,
   DependencyEdge,
   DependencyGraph,
   DependencyKind,
+  PrintReactTreeOptions,
   PrintTreeOptions,
+  ReactSymbolKind,
+  ReactUsageEdge,
+  ReactUsageEdgeKind,
+  ReactUsageFilter,
+  ReactUsageGraph,
+  ReactUsageNode,
   ReferenceKind,
   SourceModuleNode,
 } from './types.js'

--- a/src/react-analyzer.ts
+++ b/src/react-analyzer.ts
@@ -1,0 +1,1001 @@
+import fs from 'node:fs'
+import type {
+  ArrowFunctionExpression,
+  CallExpression,
+  ExportDefaultDeclaration,
+  ExportNamedDeclaration,
+  Expression,
+  FunctionBody,
+  ImportDeclaration,
+  ImportDeclarationSpecifier,
+  JSXElement,
+  JSXElementName,
+  JSXFragment,
+  ModuleExportName,
+  Node,
+  Function as OxcFunction,
+  Program,
+  Statement,
+  VariableDeclarator,
+} from 'oxc-parser'
+import { parseSync, visitorKeys } from 'oxc-parser'
+
+import { analyzeDependencies } from './analyzer.js'
+import { isSourceCodeFile, toDisplayPath } from './path-utils.js'
+import type {
+  AnalyzeOptions,
+  ReactSymbolKind,
+  ReactUsageEdge,
+  ReactUsageFilter,
+  ReactUsageGraph,
+  ReactUsageNode,
+} from './types.js'
+
+interface PendingReactUsageNode {
+  readonly id: string
+  readonly name: string
+  readonly kind: ReactSymbolKind
+  readonly filePath: string
+  readonly declaration: OxcFunction | ArrowFunctionExpression
+  readonly exportNames: Set<string>
+  readonly componentReferences: Set<string>
+  readonly hookReferences: Set<string>
+}
+
+interface ImportBinding {
+  readonly importedName: string
+  readonly sourceSpecifier: string
+  readonly sourcePath?: string
+}
+
+interface FileAnalysis {
+  readonly filePath: string
+  readonly importsByLocalName: Map<string, ImportBinding>
+  readonly exportsByName: Map<string, string>
+  readonly symbolsById: Map<string, PendingReactUsageNode>
+  readonly symbolsByName: Map<string, PendingReactUsageNode>
+}
+
+interface SerializedReactUsageNode {
+  readonly id: string
+  readonly name: string
+  readonly symbolKind: ReactSymbolKind | 'circular'
+  readonly filePath: string
+  readonly exportNames: readonly string[]
+  readonly usages: readonly SerializedReactUsageEdge[]
+}
+
+interface SerializedReactUsageEdge {
+  readonly kind: ReactUsageEdge['kind']
+  readonly targetId: string
+  readonly node: SerializedReactUsageNode
+}
+
+const FUNCTION_NODE_TYPES = new Set([
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'ArrowFunctionExpression',
+  'TSDeclareFunction',
+  'TSEmptyBodyFunctionExpression',
+])
+
+export function analyzeReactUsage(
+  entryFile: string,
+  options: AnalyzeOptions = {},
+): ReactUsageGraph {
+  const dependencyGraph = analyzeDependencies(entryFile, options)
+  const reachableFiles = new Set<string>([
+    dependencyGraph.entryId,
+    ...dependencyGraph.nodes.keys(),
+  ])
+  const fileAnalyses = new Map<string, FileAnalysis>()
+
+  for (const filePath of [...reachableFiles].sort()) {
+    if (!isSourceCodeFile(filePath) || filePath.endsWith('.d.ts')) {
+      continue
+    }
+
+    const sourceText = fs.readFileSync(filePath, 'utf8')
+    const parseResult = parseSync(filePath, sourceText, {
+      astType: 'ts',
+      sourceType: 'unambiguous',
+    })
+
+    const dependencyNode = dependencyGraph.nodes.get(filePath)
+    const sourceDependencies = new Map<string, string>()
+    dependencyNode?.dependencies.forEach((dependency) => {
+      if (dependency.kind === 'source') {
+        sourceDependencies.set(dependency.specifier, dependency.target)
+      }
+    })
+
+    fileAnalyses.set(
+      filePath,
+      analyzeReactFile(parseResult.program, filePath, sourceDependencies),
+    )
+  }
+
+  const nodes = new Map<string, ReactUsageNode>()
+  for (const fileAnalysis of fileAnalyses.values()) {
+    for (const symbol of fileAnalysis.symbolsById.values()) {
+      nodes.set(symbol.id, {
+        id: symbol.id,
+        name: symbol.name,
+        kind: symbol.kind,
+        filePath: symbol.filePath,
+        exportNames: [...symbol.exportNames].sort(),
+        usages: [],
+      })
+    }
+  }
+
+  for (const fileAnalysis of fileAnalyses.values()) {
+    fileAnalysis.importsByLocalName.forEach((binding, localName) => {
+      if (binding.sourcePath !== undefined) {
+        return
+      }
+
+      if (!isHookName(localName) && !isHookName(binding.importedName)) {
+        return
+      }
+
+      const externalNode = createExternalHookNode(binding, localName)
+      if (!nodes.has(externalNode.id)) {
+        nodes.set(externalNode.id, externalNode)
+      }
+    })
+  }
+
+  for (const fileAnalysis of fileAnalyses.values()) {
+    for (const symbol of fileAnalysis.symbolsById.values()) {
+      const usages = new Map<string, ReactUsageEdge>()
+
+      symbol.componentReferences.forEach((referenceName) => {
+        const targetId = resolveReactReference(
+          fileAnalysis,
+          fileAnalyses,
+          referenceName,
+          'component',
+        )
+        if (targetId !== undefined && targetId !== symbol.id) {
+          usages.set(`render:${targetId}`, {
+            kind: 'render',
+            target: targetId,
+          })
+        }
+      })
+
+      symbol.hookReferences.forEach((referenceName) => {
+        const targetId = resolveReactReference(
+          fileAnalysis,
+          fileAnalyses,
+          referenceName,
+          'hook',
+        )
+        if (targetId !== undefined && targetId !== symbol.id) {
+          usages.set(`hook:${targetId}`, {
+            kind: 'hook-call',
+            target: targetId,
+          })
+        }
+      })
+
+      const node = nodes.get(symbol.id)
+      if (node === undefined) {
+        continue
+      }
+
+      const sortedUsages = [...usages.values()].sort((left, right) =>
+        compareReactNodeIds(left.target, right.target, nodes),
+      )
+
+      nodes.set(symbol.id, {
+        ...node,
+        usages: sortedUsages,
+      })
+    }
+  }
+
+  return {
+    cwd: dependencyGraph.cwd,
+    entryId: dependencyGraph.entryId,
+    nodes,
+  }
+}
+
+export function graphToSerializableReactTree(
+  graph: ReactUsageGraph,
+  options: {
+    readonly filter?: ReactUsageFilter
+  } = {},
+): object {
+  const roots = getReactUsageRoots(graph, options.filter)
+
+  return {
+    kind: 'react-usage',
+    roots: roots.map((rootId) =>
+      serializeReactUsageNode(
+        rootId,
+        graph,
+        options.filter ?? 'all',
+        new Set(),
+      ),
+    ),
+  }
+}
+
+export function getReactUsageRoots(
+  graph: ReactUsageGraph,
+  filter: ReactUsageFilter = 'all',
+): string[] {
+  const filteredNodes = getFilteredReactUsageNodes(graph, filter)
+  const inboundCounts = new Map<string, number>()
+
+  filteredNodes.forEach((node) => {
+    inboundCounts.set(node.id, 0)
+  })
+
+  filteredNodes.forEach((node) => {
+    getFilteredUsages(node, graph, filter).forEach((usage) => {
+      inboundCounts.set(
+        usage.target,
+        (inboundCounts.get(usage.target) ?? 0) + 1,
+      )
+    })
+  })
+
+  const roots = filteredNodes
+    .filter((node) => (inboundCounts.get(node.id) ?? 0) === 0)
+    .map((node) => node.id)
+
+  if (roots.length > 0) {
+    return roots.sort((left, right) =>
+      compareReactNodeIds(left, right, graph.nodes),
+    )
+  }
+
+  return filteredNodes
+    .map((node) => node.id)
+    .sort((left, right) => compareReactNodeIds(left, right, graph.nodes))
+}
+
+export function getFilteredUsages(
+  node: ReactUsageNode,
+  graph: ReactUsageGraph,
+  filter: ReactUsageFilter = 'all',
+): ReactUsageEdge[] {
+  return node.usages.filter((usage) => {
+    const targetNode = graph.nodes.get(usage.target)
+    return targetNode !== undefined && matchesReactFilter(targetNode, filter)
+  })
+}
+
+function analyzeReactFile(
+  program: Program,
+  filePath: string,
+  sourceDependencies: ReadonlyMap<string, string>,
+): FileAnalysis {
+  const symbolsByName = new Map<string, PendingReactUsageNode>()
+
+  program.body.forEach((statement) => {
+    collectTopLevelReactSymbols(statement, filePath, symbolsByName)
+  })
+
+  const importsByLocalName = new Map<string, ImportBinding>()
+  const exportsByName = new Map<string, string>()
+
+  program.body.forEach((statement) => {
+    collectImportsAndExports(
+      statement,
+      sourceDependencies,
+      symbolsByName,
+      importsByLocalName,
+      exportsByName,
+    )
+  })
+
+  symbolsByName.forEach((symbol) => {
+    analyzeSymbolUsages(symbol)
+  })
+
+  return {
+    filePath,
+    importsByLocalName,
+    exportsByName,
+    symbolsById: new Map(
+      [...symbolsByName.values()].map((symbol) => [symbol.id, symbol]),
+    ),
+    symbolsByName,
+  }
+}
+
+function collectTopLevelReactSymbols(
+  statement: Statement,
+  filePath: string,
+  symbolsByName: Map<string, PendingReactUsageNode>,
+): void {
+  switch (statement.type) {
+    case 'FunctionDeclaration':
+      addFunctionSymbol(statement, filePath, symbolsByName)
+      return
+    case 'VariableDeclaration':
+      statement.declarations.forEach((declarator) => {
+        addVariableSymbol(declarator, filePath, symbolsByName)
+      })
+      return
+    case 'ExportNamedDeclaration':
+      if (statement.declaration !== null) {
+        collectTopLevelReactSymbols(
+          statement.declaration,
+          filePath,
+          symbolsByName,
+        )
+      }
+      return
+    case 'ExportDefaultDeclaration':
+      addDefaultExportSymbol(statement, filePath, symbolsByName)
+      return
+    default:
+      return
+  }
+}
+
+function addFunctionSymbol(
+  declaration: OxcFunction,
+  filePath: string,
+  symbolsByName: Map<string, PendingReactUsageNode>,
+): void {
+  const name = declaration.id?.name
+  if (name === undefined) {
+    return
+  }
+
+  const kind = classifyReactSymbol(name, declaration)
+  if (kind === undefined) {
+    return
+  }
+
+  symbolsByName.set(
+    name,
+    createPendingSymbol(filePath, name, kind, declaration),
+  )
+}
+
+function addVariableSymbol(
+  declarator: VariableDeclarator,
+  filePath: string,
+  symbolsByName: Map<string, PendingReactUsageNode>,
+): void {
+  if (declarator.id.type !== 'Identifier' || declarator.init === null) {
+    return
+  }
+
+  if (
+    declarator.init.type !== 'ArrowFunctionExpression' &&
+    declarator.init.type !== 'FunctionExpression'
+  ) {
+    return
+  }
+
+  const name = declarator.id.name
+  const kind = classifyReactSymbol(name, declarator.init)
+  if (kind === undefined) {
+    return
+  }
+
+  symbolsByName.set(
+    name,
+    createPendingSymbol(filePath, name, kind, declarator.init),
+  )
+}
+
+function addDefaultExportSymbol(
+  declaration: ExportDefaultDeclaration,
+  filePath: string,
+  symbolsByName: Map<string, PendingReactUsageNode>,
+): void {
+  if (
+    declaration.declaration.type === 'FunctionDeclaration' ||
+    declaration.declaration.type === 'FunctionExpression'
+  ) {
+    addFunctionSymbol(declaration.declaration, filePath, symbolsByName)
+  } else if (declaration.declaration.type === 'ArrowFunctionExpression') {
+    const name = 'default'
+    const kind = declaration.declaration.body
+      ? classifyReactSymbol(name, declaration.declaration)
+      : undefined
+    if (kind !== undefined) {
+      symbolsByName.set(
+        name,
+        createPendingSymbol(filePath, name, kind, declaration.declaration),
+      )
+    }
+  }
+}
+
+function createPendingSymbol(
+  filePath: string,
+  name: string,
+  kind: ReactSymbolKind,
+  declaration: OxcFunction | ArrowFunctionExpression,
+): PendingReactUsageNode {
+  return {
+    id: `${filePath}#${kind}:${name}`,
+    name,
+    kind,
+    filePath,
+    declaration,
+    exportNames: new Set<string>(),
+    componentReferences: new Set<string>(),
+    hookReferences: new Set<string>(),
+  }
+}
+
+function collectImportsAndExports(
+  statement: Statement,
+  sourceDependencies: ReadonlyMap<string, string>,
+  symbolsByName: ReadonlyMap<string, PendingReactUsageNode>,
+  importsByLocalName: Map<string, ImportBinding>,
+  exportsByName: Map<string, string>,
+): void {
+  switch (statement.type) {
+    case 'ImportDeclaration':
+      collectImportBindings(statement, sourceDependencies, importsByLocalName)
+      return
+    case 'ExportNamedDeclaration':
+      collectNamedExports(statement, symbolsByName, exportsByName)
+      return
+    case 'ExportDefaultDeclaration':
+      collectDefaultExport(statement, symbolsByName, exportsByName)
+      return
+    default:
+      return
+  }
+}
+
+function collectImportBindings(
+  declaration: ImportDeclaration,
+  sourceDependencies: ReadonlyMap<string, string>,
+  importsByLocalName: Map<string, ImportBinding>,
+): void {
+  if (declaration.importKind === 'type') {
+    return
+  }
+
+  const sourceSpecifier = declaration.source.value
+  const sourcePath = sourceDependencies.get(declaration.source.value)
+
+  declaration.specifiers.forEach((specifier) => {
+    const binding = getImportBinding(specifier, sourceSpecifier, sourcePath)
+    if (binding === undefined) {
+      return
+    }
+
+    importsByLocalName.set(binding.localName, {
+      importedName: binding.importedName,
+      sourceSpecifier: binding.sourceSpecifier,
+      ...(binding.sourcePath === undefined
+        ? {}
+        : { sourcePath: binding.sourcePath }),
+    })
+  })
+}
+
+function getImportBinding(
+  specifier: ImportDeclarationSpecifier,
+  sourceSpecifier: string,
+  sourcePath: string | undefined,
+):
+  | {
+      readonly localName: string
+      readonly importedName: string
+      readonly sourceSpecifier: string
+      readonly sourcePath?: string
+    }
+  | undefined {
+  if (specifier.type === 'ImportSpecifier') {
+    if (specifier.importKind === 'type') {
+      return undefined
+    }
+
+    return {
+      localName: specifier.local.name,
+      importedName: toModuleExportName(specifier.imported),
+      sourceSpecifier,
+      ...(sourcePath === undefined ? {} : { sourcePath }),
+    }
+  }
+
+  if (specifier.type === 'ImportDefaultSpecifier') {
+    return {
+      localName: specifier.local.name,
+      importedName: 'default',
+      sourceSpecifier,
+      ...(sourcePath === undefined ? {} : { sourcePath }),
+    }
+  }
+
+  return undefined
+}
+
+function collectNamedExports(
+  declaration: ExportNamedDeclaration,
+  symbolsByName: ReadonlyMap<string, PendingReactUsageNode>,
+  exportsByName: Map<string, string>,
+): void {
+  if (declaration.exportKind === 'type') {
+    return
+  }
+
+  if (declaration.declaration !== null) {
+    if (declaration.declaration.type === 'FunctionDeclaration') {
+      const name = declaration.declaration.id?.name
+      if (name !== undefined) {
+        addExportBinding(name, name, symbolsByName, exportsByName)
+      }
+    } else if (declaration.declaration.type === 'VariableDeclaration') {
+      declaration.declaration.declarations.forEach((declarator) => {
+        if (declarator.id.type === 'Identifier') {
+          addExportBinding(
+            declarator.id.name,
+            declarator.id.name,
+            symbolsByName,
+            exportsByName,
+          )
+        }
+      })
+    }
+
+    return
+  }
+
+  if (declaration.source !== null) {
+    return
+  }
+
+  declaration.specifiers.forEach((specifier) => {
+    if (specifier.exportKind === 'type') {
+      return
+    }
+
+    const localName = toModuleExportName(specifier.local)
+    const exportedName = toModuleExportName(specifier.exported)
+    addExportBinding(localName, exportedName, symbolsByName, exportsByName)
+  })
+}
+
+function collectDefaultExport(
+  declaration: ExportDefaultDeclaration,
+  symbolsByName: ReadonlyMap<string, PendingReactUsageNode>,
+  exportsByName: Map<string, string>,
+): void {
+  if (
+    declaration.declaration.type === 'FunctionDeclaration' ||
+    declaration.declaration.type === 'FunctionExpression'
+  ) {
+    const localName = declaration.declaration.id?.name
+    if (localName !== undefined) {
+      addExportBinding(localName, 'default', symbolsByName, exportsByName)
+    }
+    return
+  }
+
+  if (declaration.declaration.type === 'Identifier') {
+    addExportBinding(
+      declaration.declaration.name,
+      'default',
+      symbolsByName,
+      exportsByName,
+    )
+    return
+  }
+
+  if (declaration.declaration.type === 'ArrowFunctionExpression') {
+    addExportBinding('default', 'default', symbolsByName, exportsByName)
+  }
+}
+
+function addExportBinding(
+  localName: string,
+  exportedName: string,
+  symbolsByName: ReadonlyMap<string, PendingReactUsageNode>,
+  exportsByName: Map<string, string>,
+): void {
+  const symbol = symbolsByName.get(localName)
+  if (symbol === undefined) {
+    return
+  }
+
+  symbol.exportNames.add(exportedName)
+  exportsByName.set(exportedName, symbol.id)
+}
+
+function analyzeSymbolUsages(symbol: PendingReactUsageNode): void {
+  const root =
+    symbol.declaration.type === 'ArrowFunctionExpression'
+      ? symbol.declaration.body
+      : symbol.declaration.body
+
+  if (root === null) {
+    return
+  }
+
+  walkReactUsageTree(root, (node) => {
+    if (node.type === 'JSXElement') {
+      const name = getComponentReferenceName(node)
+      if (name !== undefined) {
+        symbol.componentReferences.add(name)
+      }
+      return
+    }
+
+    if (node.type === 'CallExpression') {
+      const hookReference = getHookReferenceName(node)
+      if (hookReference !== undefined) {
+        symbol.hookReferences.add(hookReference)
+      }
+
+      const componentReference = getCreateElementComponentReferenceName(node)
+      if (componentReference !== undefined) {
+        symbol.componentReferences.add(componentReference)
+      }
+    }
+  })
+}
+
+function classifyReactSymbol(
+  name: string,
+  declaration: OxcFunction | ArrowFunctionExpression,
+): ReactSymbolKind | undefined {
+  if (isHookName(name)) {
+    return 'hook'
+  }
+
+  if (isComponentName(name) && returnsReactElement(declaration)) {
+    return 'component'
+  }
+
+  return undefined
+}
+
+function returnsReactElement(
+  declaration: OxcFunction | ArrowFunctionExpression,
+): boolean {
+  if (
+    declaration.type === 'ArrowFunctionExpression' &&
+    declaration.expression
+  ) {
+    return containsReactElementLikeExpression(declaration.body as Expression)
+  }
+
+  const body = declaration.body
+  if (body === null) {
+    return false
+  }
+
+  let found = false
+  walkReactUsageTree(body, (node) => {
+    if (node.type !== 'ReturnStatement' || node.argument === null) {
+      return
+    }
+
+    if (containsReactElementLikeExpression(node.argument)) {
+      found = true
+    }
+  })
+
+  return found
+}
+
+function containsReactElementLikeExpression(expression: Expression): boolean {
+  let found = false
+
+  walkNode(expression, (node) => {
+    if (
+      node.type === 'JSXElement' ||
+      node.type === 'JSXFragment' ||
+      (node.type === 'CallExpression' && isReactCreateElementCall(node))
+    ) {
+      found = true
+    }
+  })
+
+  return found
+}
+
+function getComponentReferenceName(node: JSXElement): string | undefined {
+  const name = getJsxName(node.openingElement.name)
+  return name !== undefined && isComponentName(name) ? name : undefined
+}
+
+function getHookReferenceName(node: CallExpression): string | undefined {
+  const calleeName = getIdentifierName(node.callee)
+  return calleeName !== undefined && isHookName(calleeName)
+    ? calleeName
+    : undefined
+}
+
+function getCreateElementComponentReferenceName(
+  node: CallExpression,
+): string | undefined {
+  if (!isReactCreateElementCall(node)) {
+    return undefined
+  }
+
+  const [firstArgument] = node.arguments
+  if (firstArgument === undefined || firstArgument.type !== 'Identifier') {
+    return undefined
+  }
+
+  return isComponentName(firstArgument.name) ? firstArgument.name : undefined
+}
+
+function isReactCreateElementCall(node: CallExpression): boolean {
+  const callee = unwrapExpression(node.callee)
+  if (callee.type !== 'MemberExpression' || callee.computed) {
+    return false
+  }
+
+  return (
+    callee.object.type === 'Identifier' &&
+    callee.object.name === 'React' &&
+    callee.property.name === 'createElement'
+  )
+}
+
+function getJsxName(name: JSXElementName): string | undefined {
+  if (name.type === 'JSXIdentifier') {
+    return name.name
+  }
+
+  return undefined
+}
+
+function getIdentifierName(expression: Expression): string | undefined {
+  const unwrapped = unwrapExpression(expression)
+  return unwrapped.type === 'Identifier' ? unwrapped.name : undefined
+}
+
+function unwrapExpression(expression: Expression): Expression {
+  let current = expression
+
+  while (true) {
+    if (
+      current.type === 'ParenthesizedExpression' ||
+      current.type === 'TSAsExpression' ||
+      current.type === 'TSSatisfiesExpression' ||
+      current.type === 'TSTypeAssertion' ||
+      current.type === 'TSNonNullExpression'
+    ) {
+      current = current.expression
+      continue
+    }
+
+    return current
+  }
+}
+
+function walkReactUsageTree(
+  root: FunctionBody | Expression | JSXFragment | JSXElement,
+  visit: (node: Node) => void,
+): void {
+  walkNode(root, visit, true)
+}
+
+function walkNode(
+  node: Node,
+  visit: (node: Node) => void,
+  allowNestedFunctions = false,
+): void {
+  visit(node)
+
+  const keys = visitorKeys[node.type]
+  if (keys === undefined) {
+    return
+  }
+
+  keys.forEach((key) => {
+    const value = (node as unknown as Record<string, unknown>)[key]
+    walkChild(value, visit, allowNestedFunctions)
+  })
+}
+
+function walkChild(
+  value: unknown,
+  visit: (node: Node) => void,
+  allowNestedFunctions: boolean,
+): void {
+  if (Array.isArray(value)) {
+    value.forEach((entry) => {
+      walkChild(entry, visit, allowNestedFunctions)
+    })
+    return
+  }
+
+  if (!isNode(value)) {
+    return
+  }
+
+  if (!allowNestedFunctions && FUNCTION_NODE_TYPES.has(value.type)) {
+    return
+  }
+
+  walkNode(value, visit, false)
+}
+
+function isNode(value: unknown): value is Node {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'type' in value &&
+    typeof (value as { type: unknown }).type === 'string'
+  )
+}
+
+function resolveReactReference(
+  fileAnalysis: FileAnalysis,
+  fileAnalyses: ReadonlyMap<string, FileAnalysis>,
+  name: string,
+  kind: ReactSymbolKind,
+): string | undefined {
+  const localSymbol = fileAnalysis.symbolsByName.get(name)
+  if (localSymbol !== undefined && localSymbol.kind === kind) {
+    return localSymbol.id
+  }
+
+  const importBinding = fileAnalysis.importsByLocalName.get(name)
+  if (importBinding === undefined) {
+    return undefined
+  }
+
+  if (importBinding.sourcePath === undefined) {
+    return kind === 'hook'
+      ? getExternalHookNodeId(importBinding, name)
+      : undefined
+  }
+
+  const sourceFileAnalysis = fileAnalyses.get(importBinding.sourcePath)
+  if (sourceFileAnalysis === undefined) {
+    return undefined
+  }
+
+  const targetId = sourceFileAnalysis.exportsByName.get(
+    importBinding.importedName,
+  )
+  if (targetId === undefined) {
+    return undefined
+  }
+
+  const targetSymbol = sourceFileAnalysis.symbolsById.get(targetId)
+  return targetSymbol?.kind === kind ? targetId : undefined
+}
+
+function createExternalHookNode(
+  binding: ImportBinding,
+  localName: string,
+): ReactUsageNode {
+  const name = getExternalHookName(binding, localName)
+
+  return {
+    id: getExternalHookNodeId(binding, localName),
+    name,
+    kind: 'hook',
+    filePath: binding.sourceSpecifier,
+    exportNames: [binding.importedName],
+    usages: [],
+  }
+}
+
+function getExternalHookNodeId(
+  binding: ImportBinding,
+  localName: string,
+): string {
+  return `external:${binding.sourceSpecifier}#hook:${getExternalHookName(binding, localName)}`
+}
+
+function getExternalHookName(
+  binding: ImportBinding,
+  localName: string,
+): string {
+  return binding.importedName === 'default' ? localName : binding.importedName
+}
+
+function getFilteredReactUsageNodes(
+  graph: ReactUsageGraph,
+  filter: ReactUsageFilter,
+): ReactUsageNode[] {
+  return [...graph.nodes.values()]
+    .filter((node) => matchesReactFilter(node, filter))
+    .sort((left, right) => compareReactNodes(left, right))
+}
+
+function matchesReactFilter(
+  node: ReactUsageNode,
+  filter: ReactUsageFilter,
+): boolean {
+  return filter === 'all' || node.kind === filter
+}
+
+function serializeReactUsageNode(
+  nodeId: string,
+  graph: ReactUsageGraph,
+  filter: ReactUsageFilter,
+  visited: Set<string>,
+): SerializedReactUsageNode {
+  const node = graph.nodes.get(nodeId)
+  if (node === undefined) {
+    return {
+      id: nodeId,
+      name: nodeId,
+      symbolKind: 'circular',
+      filePath: '',
+      exportNames: [],
+      usages: [],
+    }
+  }
+
+  if (visited.has(nodeId)) {
+    return {
+      id: node.id,
+      name: node.name,
+      symbolKind: 'circular',
+      filePath: toDisplayPath(node.filePath, graph.cwd),
+      exportNames: node.exportNames,
+      usages: [],
+    }
+  }
+
+  const nextVisited = new Set(visited)
+  nextVisited.add(nodeId)
+
+  return {
+    id: node.id,
+    name: node.name,
+    symbolKind: node.kind,
+    filePath: toDisplayPath(node.filePath, graph.cwd),
+    exportNames: node.exportNames,
+    usages: getFilteredUsages(node, graph, filter).map((usage) => ({
+      kind: usage.kind,
+      targetId: usage.target,
+      node: serializeReactUsageNode(usage.target, graph, filter, nextVisited),
+    })),
+  }
+}
+
+function compareReactNodeIds(
+  leftId: string,
+  rightId: string,
+  nodes: ReadonlyMap<string, ReactUsageNode>,
+): number {
+  const left = nodes.get(leftId)
+  const right = nodes.get(rightId)
+
+  if (left === undefined || right === undefined) {
+    return leftId.localeCompare(rightId)
+  }
+
+  return compareReactNodes(left, right)
+}
+
+function compareReactNodes(
+  left: ReactUsageNode,
+  right: ReactUsageNode,
+): number {
+  return (
+    left.filePath.localeCompare(right.filePath) ||
+    left.name.localeCompare(right.name) ||
+    left.kind.localeCompare(right.kind)
+  )
+}
+
+function toModuleExportName(name: ModuleExportName): string {
+  return name.type === 'Literal' ? name.value : name.name
+}
+
+function isHookName(name: string): boolean {
+  return /^use[A-Z0-9]/.test(name)
+}
+
+function isComponentName(name: string): boolean {
+  return /^[A-Z]/.test(name)
+}

--- a/src/react-tree.ts
+++ b/src/react-tree.ts
@@ -1,0 +1,98 @@
+import { toDisplayPath } from './path-utils.js'
+import { getFilteredUsages, getReactUsageRoots } from './react-analyzer.js'
+import type {
+  PrintReactTreeOptions,
+  ReactUsageEdge,
+  ReactUsageGraph,
+  ReactUsageNode,
+} from './types.js'
+
+export function printReactUsageTree(
+  graph: ReactUsageGraph,
+  options: PrintReactTreeOptions = {},
+): string {
+  const cwd = options.cwd ?? graph.cwd
+  const filter = options.filter ?? 'all'
+  const roots = getReactUsageRoots(graph, filter)
+
+  if (roots.length === 0) {
+    return 'No React symbols found.'
+  }
+
+  const lines: string[] = []
+  roots.forEach((rootId, index) => {
+    const root = graph.nodes.get(rootId)
+    if (root === undefined) {
+      return
+    }
+
+    lines.push(formatReactNodeLabel(root, cwd))
+    const usages = getFilteredUsages(root, graph, filter)
+    usages.forEach((usage, usageIndex) => {
+      lines.push(
+        ...renderUsage(
+          usage,
+          graph,
+          cwd,
+          filter,
+          new Set([root.id]),
+          '',
+          usageIndex === usages.length - 1,
+        ),
+      )
+    })
+
+    if (index < roots.length - 1) {
+      lines.push('')
+    }
+  })
+
+  return lines.join('\n')
+}
+
+function renderUsage(
+  usage: ReactUsageEdge,
+  graph: ReactUsageGraph,
+  cwd: string,
+  filter: NonNullable<PrintReactTreeOptions['filter']>,
+  visited: ReadonlySet<string>,
+  prefix: string,
+  isLast: boolean,
+): string[] {
+  const branch = `${prefix}${isLast ? '└─ ' : '├─ '}`
+  const target = graph.nodes.get(usage.target)
+
+  if (target === undefined) {
+    return [`${branch}${usage.target}`]
+  }
+
+  if (visited.has(target.id)) {
+    return [`${branch}${formatReactNodeLabel(target, cwd)} (circular)`]
+  }
+
+  const childLines = [`${branch}${formatReactNodeLabel(target, cwd)}`]
+  const nextVisited = new Set(visited)
+  nextVisited.add(target.id)
+  const nextPrefix = `${prefix}${isLast ? '   ' : '│  '}`
+  const childUsages = getFilteredUsages(target, graph, filter)
+
+  childUsages.forEach((childUsage, index) => {
+    childLines.push(
+      ...renderUsage(
+        childUsage,
+        graph,
+        cwd,
+        filter,
+        nextVisited,
+        nextPrefix,
+        index === childUsages.length - 1,
+      ),
+    )
+  })
+
+  return childLines
+}
+
+function formatReactNodeLabel(node: ReactUsageNode, cwd: string): string {
+  return `${node.name} [${node.kind}] (${toDisplayPath(node.filePath, cwd)})`
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,3 +36,34 @@ export interface PrintTreeOptions {
   readonly cwd?: string
   readonly includeExternals?: boolean
 }
+
+export type ReactSymbolKind = 'component' | 'hook'
+
+export type ReactUsageFilter = 'all' | ReactSymbolKind
+
+export type ReactUsageEdgeKind = 'render' | 'hook-call'
+
+export interface ReactUsageEdge {
+  readonly kind: ReactUsageEdgeKind
+  readonly target: string
+}
+
+export interface ReactUsageNode {
+  readonly id: string
+  readonly name: string
+  readonly kind: ReactSymbolKind
+  readonly filePath: string
+  readonly exportNames: readonly string[]
+  readonly usages: readonly ReactUsageEdge[]
+}
+
+export interface ReactUsageGraph {
+  readonly cwd: string
+  readonly entryId: string
+  readonly nodes: ReadonlyMap<string, ReactUsageNode>
+}
+
+export interface PrintReactTreeOptions {
+  readonly cwd?: string
+  readonly filter?: ReactUsageFilter
+}

--- a/test/fixtures/react-mode/src/AppShell.tsx
+++ b/test/fixtures/react-mode/src/AppShell.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+import { DynamicHost } from './components/DynamicHost'
+import { Panel as PrimaryPanel } from './components/Panel'
+import { useFeature } from './hooks/useFeature'
+
+export function AppShell() {
+  useEffect(() => {}, [])
+  useFeature()
+
+  return (
+    <>
+      <PrimaryPanel />
+      <DynamicHost />
+    </>
+  )
+}

--- a/test/fixtures/react-mode/src/components/Button.tsx
+++ b/test/fixtures/react-mode/src/components/Button.tsx
@@ -1,0 +1,3 @@
+export function Button() {
+  return <button type="button">Press</button>
+}

--- a/test/fixtures/react-mode/src/components/DynamicHost.tsx
+++ b/test/fixtures/react-mode/src/components/DynamicHost.tsx
@@ -1,0 +1,10 @@
+import { Button } from './Button'
+
+const registry = {
+  Button,
+}
+
+export function DynamicHost() {
+  const Current = registry.Button
+  return <Current />
+}

--- a/test/fixtures/react-mode/src/components/Panel.tsx
+++ b/test/fixtures/react-mode/src/components/Panel.tsx
@@ -1,0 +1,7 @@
+import { usePanelState } from '../hooks/usePanelState'
+import { Button as PrimaryButton } from './Button'
+
+export function Panel() {
+  usePanelState()
+  return <PrimaryButton />
+}

--- a/test/fixtures/react-mode/src/hooks/useFeature.ts
+++ b/test/fixtures/react-mode/src/hooks/useFeature.ts
@@ -1,0 +1,6 @@
+import { usePanelState as usePanelStateAlias } from './usePanelState'
+
+export function useFeature() {
+  usePanelStateAlias()
+  return null
+}

--- a/test/fixtures/react-mode/src/hooks/usePanelState.ts
+++ b/test/fixtures/react-mode/src/hooks/usePanelState.ts
@@ -1,0 +1,5 @@
+export function usePanelState() {
+  return {
+    ready: true,
+  }
+}

--- a/test/fixtures/react-mode/src/main.tsx
+++ b/test/fixtures/react-mode/src/main.tsx
@@ -1,0 +1,3 @@
+import { AppShell } from './AppShell'
+
+void (<AppShell />)

--- a/test/fixtures/react-mode/tsconfig.json
+++ b/test/fixtures/react-mode/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}

--- a/test/react-analyzer.test.ts
+++ b/test/react-analyzer.test.ts
@@ -1,0 +1,108 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  analyzeReactUsage,
+  graphToSerializableReactTree,
+  printReactUsageTree,
+} from '../src/index.js'
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url))
+const fixtureDirectory = path.join(currentDirectory, 'fixtures', 'react-mode')
+
+describe('analyzeReactUsage', () => {
+  it('builds a component and hook usage tree', () => {
+    const graph = analyzeReactUsage('src/main.tsx', {
+      cwd: fixtureDirectory,
+    })
+
+    const output = printReactUsageTree(graph)
+
+    expect(output).toContain('AppShell [component] (src/AppShell.tsx)')
+    expect(output).toContain('Panel [component] (src/components/Panel.tsx)')
+    expect(output).toContain('Button [component] (src/components/Button.tsx)')
+    expect(output).toContain('useEffect [hook] (react)')
+    expect(output).toContain('useFeature [hook] (src/hooks/useFeature.ts)')
+    expect(output).toContain(
+      'usePanelState [hook] (src/hooks/usePanelState.ts)',
+    )
+    expect(output).not.toContain('Current [component]')
+  })
+
+  it('can filter the tree by component or hook', () => {
+    const graph = analyzeReactUsage('src/main.tsx', {
+      cwd: fixtureDirectory,
+    })
+
+    const componentOutput = printReactUsageTree(graph, {
+      filter: 'component',
+    })
+    const hookOutput = printReactUsageTree(graph, {
+      filter: 'hook',
+    })
+
+    expect(componentOutput).toContain('AppShell [component] (src/AppShell.tsx)')
+    expect(componentOutput).toContain(
+      'Panel [component] (src/components/Panel.tsx)',
+    )
+    expect(componentOutput).not.toContain('useFeature [hook]')
+
+    expect(hookOutput).toContain('useEffect [hook] (react)')
+    expect(hookOutput).toContain('useFeature [hook] (src/hooks/useFeature.ts)')
+    expect(hookOutput).toContain(
+      'usePanelState [hook] (src/hooks/usePanelState.ts)',
+    )
+    expect(hookOutput).not.toContain('AppShell [component]')
+  })
+
+  it('returns JSON with symbol metadata and nested usages', () => {
+    const graph = analyzeReactUsage('src/main.tsx', {
+      cwd: fixtureDirectory,
+    })
+
+    const jsonTree = graphToSerializableReactTree(graph)
+
+    expect(jsonTree).toMatchObject({
+      kind: 'react-usage',
+      roots: expect.arrayContaining([
+        expect.objectContaining({
+          name: 'AppShell',
+          symbolKind: 'component',
+          filePath: 'src/AppShell.tsx',
+          usages: expect.arrayContaining([
+            expect.objectContaining({
+              kind: 'render',
+              node: expect.objectContaining({
+                name: 'DynamicHost',
+                symbolKind: 'component',
+              }),
+            }),
+            expect.objectContaining({
+              kind: 'render',
+              node: expect.objectContaining({
+                name: 'Panel',
+                symbolKind: 'component',
+              }),
+            }),
+            expect.objectContaining({
+              kind: 'hook-call',
+              node: expect.objectContaining({
+                name: 'useEffect',
+                symbolKind: 'hook',
+              }),
+            }),
+            expect.objectContaining({
+              kind: 'hook-call',
+              node: expect.objectContaining({
+                name: 'useFeature',
+                symbolKind: 'hook',
+              }),
+            }),
+          ]),
+        }),
+      ]),
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add a React-only usage tree mode powered by `oxc-parser`
- support `--react`, `--react=component`, `--react=hook`, and React JSON output
- include local and external hook detection plus fixture-based coverage

## Testing
- `pnpm run check`

Closes #3
