### PR TITLE
docs(agent): disallow issue title prefixes

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -6,6 +6,7 @@ This repository is GitHub-first. Agents and contributors must follow these rules
 
 1. Start with a GitHub issue. If no issue exists yet, create one before making code changes.
    Issue titles must be written in natural language, not in Conventional Commit format.
+   Do not add category prefixes such as `[Feature]:`, `[Fix]:`, or similar tags to issue titles.
 2. Create a working branch from `dev`. Branch names must follow `codex/issue-<number>-<slug>`.
 3. Open a pull request for every change. Direct pushes to `dev` and `main` are not allowed.
    Pull request titles must follow the Conventional Commit pattern.


### PR DESCRIPTION
## Summary
- clarify that issue titles must not include category prefixes like `[Feature]:` or `[Fix]:`

## Validation
- ran `pnpm run check`

Closes #10