### PR TITLE
feat: support unused import filtering

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -22,6 +22,7 @@ interface ModuleReference {
   readonly specifier: string
   readonly referenceKind: ReferenceKind
   readonly isTypeOnly: boolean
+  readonly unused: boolean
 }
 
 const BUILTIN_MODULES = new Set(
@@ -49,7 +50,9 @@ export function analyzeDependencies(
   }
 
   const nodes = new Map<string, SourceModuleNode>()
-  visitFile(resolvedEntryPath, compilerOptions, host, nodes)
+  const program = createProgram(resolvedEntryPath, compilerOptions, cwd)
+  const checker = program.getTypeChecker()
+  visitFile(resolvedEntryPath, compilerOptions, host, checker, program, nodes)
 
   return {
     cwd,
@@ -59,15 +62,26 @@ export function analyzeDependencies(
   }
 }
 
-export function graphToSerializableTree(graph: DependencyGraph): object {
+export function graphToSerializableTree(
+  graph: DependencyGraph,
+  options: {
+    readonly omitUnused?: boolean
+  } = {},
+): object {
   const visited = new Set<string>()
-  return serializeNode(graph.entryId, graph, visited)
+  return serializeNode(
+    graph.entryId,
+    graph,
+    visited,
+    options.omitUnused ?? false,
+  )
 }
 
 function serializeNode(
   filePath: string,
   graph: DependencyGraph,
   visited: Set<string>,
+  omitUnused: boolean,
 ): object {
   const node = graph.nodes.get(filePath)
   const displayPath = toDisplayPath(filePath, graph.cwd)
@@ -90,29 +104,38 @@ function serializeNode(
 
   visited.add(filePath)
 
-  const dependencies = node.dependencies.map((dependency) => {
-    if (dependency.kind !== 'source') {
+  const dependencies = node.dependencies
+    .filter((dependency) => !omitUnused || !dependency.unused)
+    .map((dependency) => {
+      if (dependency.kind !== 'source') {
+        return {
+          specifier: dependency.specifier,
+          referenceKind: dependency.referenceKind,
+          isTypeOnly: dependency.isTypeOnly,
+          unused: dependency.unused,
+          kind: dependency.kind,
+          target:
+            dependency.kind === 'missing'
+              ? dependency.target
+              : toDisplayPath(dependency.target, graph.cwd),
+        }
+      }
+
       return {
         specifier: dependency.specifier,
         referenceKind: dependency.referenceKind,
         isTypeOnly: dependency.isTypeOnly,
+        unused: dependency.unused,
         kind: dependency.kind,
-        target:
-          dependency.kind === 'missing'
-            ? dependency.target
-            : toDisplayPath(dependency.target, graph.cwd),
+        target: toDisplayPath(dependency.target, graph.cwd),
+        node: serializeNode(
+          dependency.target,
+          graph,
+          new Set(visited),
+          omitUnused,
+        ),
       }
-    }
-
-    return {
-      specifier: dependency.specifier,
-      referenceKind: dependency.referenceKind,
-      isTypeOnly: dependency.isTypeOnly,
-      kind: dependency.kind,
-      target: toDisplayPath(dependency.target, graph.cwd),
-      node: serializeNode(dependency.target, graph, new Set(visited)),
-    }
-  })
+    })
 
   return {
     path: displayPath,
@@ -125,6 +148,8 @@ function visitFile(
   filePath: string,
   compilerOptions: ts.CompilerOptions,
   host: ts.ModuleResolutionHost,
+  checker: ts.TypeChecker,
+  program: ts.Program,
   nodes: Map<string, SourceModuleNode>,
 ): void {
   const normalizedPath = normalizeFilePath(filePath)
@@ -132,16 +157,10 @@ function visitFile(
     return
   }
 
-  const sourceText = fs.readFileSync(normalizedPath, 'utf8')
-  const sourceFile = ts.createSourceFile(
-    normalizedPath,
-    sourceText,
-    ts.ScriptTarget.Latest,
-    true,
-    getScriptKind(normalizedPath),
-  )
+  const sourceFile =
+    program.getSourceFile(normalizedPath) ?? createSourceFile(normalizedPath)
 
-  const references = collectModuleReferences(sourceFile)
+  const references = collectModuleReferences(sourceFile, checker)
   const dependencies = references.map((reference) =>
     resolveDependency(reference, normalizedPath, compilerOptions, host),
   )
@@ -153,30 +172,48 @@ function visitFile(
 
   for (const dependency of dependencies) {
     if (dependency.kind === 'source') {
-      visitFile(dependency.target, compilerOptions, host, nodes)
+      visitFile(
+        dependency.target,
+        compilerOptions,
+        host,
+        checker,
+        program,
+        nodes,
+      )
     }
   }
 }
 
-function collectModuleReferences(sourceFile: ts.SourceFile): ModuleReference[] {
-  const references: ModuleReference[] = []
-  const seen = new Set<string>()
+function collectModuleReferences(
+  sourceFile: ts.SourceFile,
+  checker: ts.TypeChecker,
+): ModuleReference[] {
+  const references = new Map<string, ModuleReference>()
+  const unusedImports = collectUnusedImports(sourceFile, checker)
 
   function addReference(
     specifier: string,
     referenceKind: ReferenceKind,
     isTypeOnly: boolean,
+    unused: boolean,
   ): void {
     const key = `${referenceKind}:${isTypeOnly ? 'type' : 'value'}:${specifier}`
-    if (seen.has(key)) {
+    const existing = references.get(key)
+    if (existing !== undefined) {
+      if (existing.unused && !unused) {
+        references.set(key, {
+          ...existing,
+          unused: false,
+        })
+      }
       return
     }
 
-    seen.add(key)
-    references.push({
+    references.set(key, {
       specifier,
       referenceKind,
       isTypeOnly,
+      unused,
     })
   }
 
@@ -189,6 +226,7 @@ function collectModuleReferences(sourceFile: ts.SourceFile): ModuleReference[] {
         node.moduleSpecifier.text,
         'import',
         node.importClause?.isTypeOnly ?? false,
+        unusedImports.get(node) ?? false,
       )
     } else if (
       ts.isExportDeclaration(node) &&
@@ -199,6 +237,7 @@ function collectModuleReferences(sourceFile: ts.SourceFile): ModuleReference[] {
         node.moduleSpecifier.text,
         'export',
         node.isTypeOnly ?? false,
+        false,
       )
     } else if (ts.isImportEqualsDeclaration(node)) {
       const moduleReference = node.moduleReference
@@ -207,7 +246,12 @@ function collectModuleReferences(sourceFile: ts.SourceFile): ModuleReference[] {
         moduleReference.expression !== undefined &&
         ts.isStringLiteralLike(moduleReference.expression)
       ) {
-        addReference(moduleReference.expression.text, 'import-equals', false)
+        addReference(
+          moduleReference.expression.text,
+          'import-equals',
+          false,
+          false,
+        )
       }
     } else if (ts.isCallExpression(node)) {
       if (
@@ -216,7 +260,7 @@ function collectModuleReferences(sourceFile: ts.SourceFile): ModuleReference[] {
       ) {
         const [argument] = node.arguments
         if (argument !== undefined && ts.isStringLiteralLike(argument)) {
-          addReference(argument.text, 'dynamic-import', false)
+          addReference(argument.text, 'dynamic-import', false, false)
         }
       }
 
@@ -227,7 +271,7 @@ function collectModuleReferences(sourceFile: ts.SourceFile): ModuleReference[] {
       ) {
         const [argument] = node.arguments
         if (argument !== undefined && ts.isStringLiteralLike(argument)) {
-          addReference(argument.text, 'require', false)
+          addReference(argument.text, 'require', false, false)
         }
       }
     }
@@ -236,7 +280,7 @@ function collectModuleReferences(sourceFile: ts.SourceFile): ModuleReference[] {
   }
 
   visit(sourceFile)
-  return references
+  return [...references.values()]
 }
 
 function resolveDependency(
@@ -287,8 +331,188 @@ function createEdge(
     specifier: reference.specifier,
     referenceKind: reference.referenceKind,
     isTypeOnly: reference.isTypeOnly,
+    unused: reference.unused,
     kind,
     target,
+  }
+}
+
+function createProgram(
+  entryFile: string,
+  compilerOptions: ts.CompilerOptions,
+  cwd: string,
+): ts.Program {
+  const host = ts.createCompilerHost(compilerOptions, true)
+  host.getCurrentDirectory = () => cwd
+
+  if (ts.sys.realpath !== undefined) {
+    host.realpath = ts.sys.realpath
+  }
+
+  return ts.createProgram({
+    rootNames: [entryFile],
+    options: compilerOptions,
+    host,
+  })
+}
+
+function createSourceFile(filePath: string): ts.SourceFile {
+  const sourceText = fs.readFileSync(filePath, 'utf8')
+  return ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    getScriptKind(filePath),
+  )
+}
+
+function collectUnusedImports(
+  sourceFile: ts.SourceFile,
+  checker: ts.TypeChecker,
+): ReadonlyMap<ts.ImportDeclaration, boolean> {
+  const importUsage = new Map<
+    ts.ImportDeclaration,
+    {
+      canTrack: boolean
+      used: boolean
+    }
+  >()
+  const symbolToImportDeclaration = new Map<ts.Symbol, ts.ImportDeclaration>()
+  const importedLocalNames = new Set<string>()
+
+  sourceFile.statements.forEach((statement) => {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      statement.importClause === undefined
+    ) {
+      return
+    }
+
+    const identifiers = getImportBindingIdentifiers(statement.importClause)
+    if (identifiers.length === 0) {
+      return
+    }
+
+    importUsage.set(statement, {
+      canTrack: false,
+      used: false,
+    })
+
+    identifiers.forEach((identifier) => {
+      importedLocalNames.add(identifier.text)
+
+      const symbol = tryGetSymbolAtLocation(checker, identifier)
+      if (symbol === undefined) {
+        return
+      }
+
+      symbolToImportDeclaration.set(symbol, statement)
+      const state = importUsage.get(statement)
+      if (state !== undefined) {
+        state.canTrack = true
+      }
+    })
+  })
+
+  function visit(node: ts.Node): void {
+    if (ts.isImportDeclaration(node)) {
+      return
+    }
+
+    if (
+      ts.isIdentifier(node) &&
+      importedLocalNames.has(node.text) &&
+      isReferenceIdentifier(node)
+    ) {
+      const symbol = tryGetSymbolAtLocation(checker, node)
+      const declaration =
+        symbol === undefined ? undefined : symbolToImportDeclaration.get(symbol)
+      if (declaration !== undefined) {
+        const state = importUsage.get(declaration)
+        if (state !== undefined) {
+          state.used = true
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+
+  return new Map(
+    [...importUsage.entries()].map(([declaration, state]) => [
+      declaration,
+      state.canTrack && !state.used,
+    ]),
+  )
+}
+
+function getImportBindingIdentifiers(
+  importClause: ts.ImportClause,
+): ts.Identifier[] {
+  const identifiers: ts.Identifier[] = []
+
+  if (importClause.name !== undefined) {
+    identifiers.push(importClause.name)
+  }
+
+  const namedBindings = importClause.namedBindings
+  if (namedBindings === undefined) {
+    return identifiers
+  }
+
+  if (ts.isNamespaceImport(namedBindings)) {
+    identifiers.push(namedBindings.name)
+    return identifiers
+  }
+
+  namedBindings.elements.forEach((element) => {
+    identifiers.push(element.name)
+  })
+
+  return identifiers
+}
+
+function isReferenceIdentifier(node: ts.Identifier): boolean {
+  const parent = node.parent
+
+  if (ts.isPropertyAccessExpression(parent) && parent.name === node) {
+    return false
+  }
+
+  if (ts.isQualifiedName(parent) && parent.right === node) {
+    return false
+  }
+
+  if (ts.isPropertyAssignment(parent) && parent.name === node) {
+    return false
+  }
+
+  if (ts.isBindingElement(parent) && parent.propertyName === node) {
+    return false
+  }
+
+  if (ts.isJsxAttribute(parent) && parent.name === node) {
+    return false
+  }
+
+  if (ts.isExportSpecifier(parent)) {
+    return parent.propertyName === node || parent.propertyName === undefined
+  }
+
+  return true
+}
+
+function tryGetSymbolAtLocation(
+  checker: ts.TypeChecker,
+  node: ts.Node,
+): ts.Symbol | undefined {
+  try {
+    return checker.getSymbolAtLocation(node)
+  } catch {
+    return undefined
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ interface CliOptions {
   readonly cwd: string | undefined
   readonly configPath: string | undefined
   readonly includeExternals: boolean
+  readonly omitUnused: boolean
   readonly json: boolean
   readonly react: ReactUsageFilter | undefined
 }
@@ -67,7 +68,13 @@ function main(): void {
 
     if (options.json) {
       process.stdout.write(
-        `${JSON.stringify(graphToSerializableTree(graph), null, 2)}\n`,
+        `${JSON.stringify(
+          graphToSerializableTree(graph, {
+            omitUnused: options.omitUnused,
+          }),
+          null,
+          2,
+        )}\n`,
       )
       return
     }
@@ -76,6 +83,7 @@ function main(): void {
       `${printDependencyTree(graph, {
         cwd: options.cwd ?? graph.cwd,
         includeExternals: options.includeExternals,
+        omitUnused: options.omitUnused,
       })}\n`,
     )
   } catch (error) {
@@ -101,6 +109,7 @@ function parseArgs(argv: string[]): CliOptions {
   let cwd: string | undefined
   let configPath: string | undefined
   let includeExternals = false
+  let omitUnused = false
   let json = false
   let react: ReactUsageFilter | undefined
 
@@ -124,6 +133,11 @@ function parseArgs(argv: string[]): CliOptions {
 
     if (argument === '--include-externals') {
       includeExternals = true
+      continue
+    }
+
+    if (argument === '--no-unused') {
+      omitUnused = true
       continue
     }
 
@@ -167,6 +181,7 @@ function parseArgs(argv: string[]): CliOptions {
     cwd,
     configPath,
     includeExternals,
+    omitUnused,
     json,
     react,
   }
@@ -195,6 +210,7 @@ Options:
   --cwd <path>               Working directory used for relative paths.
   --config <path>            Explicit tsconfig.json or jsconfig.json path.
   --include-externals        Include packages and Node built-ins in the tree.
+  --no-unused                Omit imports that are never referenced.
   --react[=component|hook]   Print a React usage tree instead of the import tree.
   --json                     Print the dependency tree as JSON.
   -v, --version              Show the current version.

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -11,6 +11,7 @@ export function printDependencyTree(
 ): string {
   const cwd = options.cwd ?? graph.cwd
   const includeExternals = options.includeExternals ?? false
+  const omitUnused = options.omitUnused ?? false
   const rootLines = [toDisplayPath(graph.entryId, cwd)]
   const visited = new Set<string>([graph.entryId])
   const entryNode = graph.nodes.get(graph.entryId)
@@ -22,6 +23,7 @@ export function printDependencyTree(
   const rootDependencies = filterDependencies(
     entryNode.dependencies,
     includeExternals,
+    omitUnused,
   )
 
   rootDependencies.forEach((dependency, index) => {
@@ -33,6 +35,7 @@ export function printDependencyTree(
       '',
       isLast,
       includeExternals,
+      omitUnused,
       cwd,
     )
     rootLines.push(...lines)
@@ -48,6 +51,7 @@ function renderDependency(
   prefix: string,
   isLast: boolean,
   includeExternals: boolean,
+  omitUnused: boolean,
   cwd: string,
 ): string[] {
   const branch = `${prefix}${isLast ? '└─ ' : '├─ '}`
@@ -74,6 +78,7 @@ function renderDependency(
   const childDependencies = filterDependencies(
     childNode.dependencies,
     includeExternals,
+    omitUnused,
   )
 
   childDependencies.forEach((childDependency, index) => {
@@ -86,6 +91,7 @@ function renderDependency(
         nextPrefix,
         isChildLast,
         includeExternals,
+        omitUnused,
         cwd,
       ),
     )
@@ -97,8 +103,13 @@ function renderDependency(
 function filterDependencies(
   dependencies: readonly DependencyEdge[],
   includeExternals: boolean,
+  omitUnused: boolean,
 ): DependencyEdge[] {
   return dependencies.filter((dependency) => {
+    if (omitUnused && dependency.unused) {
+      return false
+    }
+
     if (dependency.kind === 'source' || dependency.kind === 'missing') {
       return true
     }
@@ -130,16 +141,32 @@ function formatDependencyLabel(
   const annotation = prefixes.length > 0 ? `[${prefixes.join(', ')}] ` : ''
 
   if (dependency.kind === 'source') {
-    return `${annotation}${toDisplayPath(dependency.target, cwd)}`
+    return withUnusedSuffix(
+      `${annotation}${toDisplayPath(dependency.target, cwd)}`,
+      dependency.unused,
+    )
   }
 
   if (dependency.kind === 'missing') {
-    return `${annotation}${dependency.specifier} [missing]`
+    return withUnusedSuffix(
+      `${annotation}${dependency.specifier} [missing]`,
+      dependency.unused,
+    )
   }
 
   if (dependency.kind === 'builtin') {
-    return `${annotation}${dependency.target} [builtin]`
+    return withUnusedSuffix(
+      `${annotation}${dependency.target} [builtin]`,
+      dependency.unused,
+    )
   }
 
-  return `${annotation}${dependency.target} [external]`
+  return withUnusedSuffix(
+    `${annotation}${dependency.target} [external]`,
+    dependency.unused,
+  )
+}
+
+function withUnusedSuffix(label: string, unused: boolean): string {
+  return unused ? `${label} (unused)` : label
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface DependencyEdge {
   readonly specifier: string
   readonly referenceKind: ReferenceKind
   readonly isTypeOnly: boolean
+  readonly unused: boolean
   readonly kind: DependencyKind
   readonly target: string
 }
@@ -35,6 +36,7 @@ export interface AnalyzeOptions {
 export interface PrintTreeOptions {
   readonly cwd?: string
   readonly includeExternals?: boolean
+  readonly omitUnused?: boolean
 }
 
 export type ReactSymbolKind = 'component' | 'hook'

--- a/test/analyzer.test.ts
+++ b/test/analyzer.test.ts
@@ -27,9 +27,12 @@ describe('analyzeDependencies', () => {
     expect(
       graph.nodes.has(path.join(fixtureDirectory, 'src', 'shared', 'util.ts')),
     ).toBe(true)
+    expect(
+      graph.nodes.has(path.join(fixtureDirectory, 'src', 'unused-helper.ts')),
+    ).toBe(true)
   })
 
-  it('prints a readable tree and hides externals by default', () => {
+  it('prints a readable tree, marks unused imports, and hides externals by default', () => {
     const graph = analyzeDependencies('src/main.ts', {
       cwd: fixtureDirectory,
     })
@@ -39,8 +42,21 @@ describe('analyzeDependencies', () => {
     expect(output).toContain('src/main.ts')
     expect(output).toContain('src/app.tsx')
     expect(output).toContain('src/components/button.tsx')
+    expect(output).toContain('src/unused-helper.ts (unused)')
     expect(output).not.toContain('typescript [external]')
     expect(output).not.toContain('node:path [builtin]')
+  })
+
+  it('can omit unused dependencies from the tree output', () => {
+    const graph = analyzeDependencies('src/main.ts', {
+      cwd: fixtureDirectory,
+    })
+
+    const output = printDependencyTree(graph, {
+      omitUnused: true,
+    })
+
+    expect(output).not.toContain('src/unused-helper.ts')
   })
 
   it('can expose externals and json output when requested', () => {
@@ -59,5 +75,94 @@ describe('analyzeDependencies', () => {
       kind: 'entry',
       path: 'src/main.ts',
     })
+    expect(
+      findDependencyByPath(jsonTree, 'src/unused-helper.ts'),
+    ).toMatchObject({
+      kind: 'source',
+      path: 'src/unused-helper.ts',
+    })
+    expect(
+      findDependencyEdgeByTarget(jsonTree, 'src/unused-helper.ts'),
+    ).toMatchObject({
+      target: 'src/unused-helper.ts',
+      unused: true,
+    })
+  })
+
+  it('can omit unused dependencies from json output', () => {
+    const graph = analyzeDependencies('src/main.ts', {
+      cwd: fixtureDirectory,
+    })
+
+    const jsonTree = graphToSerializableTree(graph, {
+      omitUnused: true,
+    })
+
+    expect(
+      findDependencyByPath(jsonTree, 'src/unused-helper.ts'),
+    ).toBeUndefined()
+    expect(
+      findDependencyEdgeByTarget(jsonTree, 'src/unused-helper.ts'),
+    ).toBeUndefined()
   })
 })
+
+function findDependencyByPath(
+  tree: object,
+  targetPath: string,
+): Record<string, unknown> | undefined {
+  if (!isRecord(tree)) {
+    return undefined
+  }
+
+  if (tree.path === targetPath) {
+    return tree
+  }
+
+  const dependencies = Array.isArray(tree.dependencies) ? tree.dependencies : []
+  for (const dependency of dependencies) {
+    if (!isRecord(dependency) || !isRecord(dependency.node)) {
+      continue
+    }
+
+    const match = findDependencyByPath(dependency.node, targetPath)
+    if (match !== undefined) {
+      return match
+    }
+  }
+
+  return undefined
+}
+
+function findDependencyEdgeByTarget(
+  tree: object,
+  targetPath: string,
+): Record<string, unknown> | undefined {
+  if (!isRecord(tree)) {
+    return undefined
+  }
+
+  const dependencies = Array.isArray(tree.dependencies) ? tree.dependencies : []
+  for (const dependency of dependencies) {
+    if (!isRecord(dependency)) {
+      continue
+    }
+
+    if (dependency.target === targetPath) {
+      return dependency
+    }
+
+    if (isRecord(dependency.node)) {
+      const match = findDependencyEdgeByTarget(dependency.node, targetPath)
+      if (match !== undefined) {
+        return match
+      }
+    }
+  }
+
+  return undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}

--- a/test/fixtures/basic/src/app.tsx
+++ b/test/fixtures/basic/src/app.tsx
@@ -1,5 +1,7 @@
 import { formatLabel } from '@/shared/util'
 import { Button } from './components/button.js'
+// biome-ignore lint/correctness/noUnusedImports: fixture for unused import detection
+import { unusedLabel } from './unused-helper.js'
 
 export function App() {
   return Button({ label: formatLabel('foresthouse') })

--- a/test/fixtures/basic/src/unused-helper.ts
+++ b/test/fixtures/basic/src/unused-helper.ts
@@ -1,0 +1,1 @@
+export const unusedLabel = 'unused'


### PR DESCRIPTION
## Summary
- track whether dependency edges come from imports that are never referenced
- mark unused dependencies as `(unused)` in tree output and support `--no-unused` to omit them
- include `unused` in JSON output and add regression coverage for tree and JSON behavior

## Testing
- pnpm lint
- pnpm test
- pnpm typecheck
- pnpm build

Closes #8