### PR TITLE
feat(cli): colorize ASCII tree output

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - Resolves local imports, re-exports, `require()`, and string-literal dynamic `import()`
 - Honors the nearest `tsconfig.json` or `jsconfig.json`, including `baseUrl` and `paths`
 - Prints a tree by default, or JSON with `--json`
+- Colorizes ASCII output automatically when the terminal supports ANSI colors
 
 ## Usage
 

--- a/docs/issues/colorize-ascii-output.md
+++ b/docs/issues/colorize-ascii-output.md
@@ -1,0 +1,46 @@
+# Add colorized ASCII output for unused nodes and React symbols
+
+## Summary
+
+The CLI currently prints plain ASCII trees only. We want to add terminal color to improve scanability, with a couple of specific requirements:
+
+- Render the `(unused)` marker in orange.
+- In React mode, render components and hooks with different colors.
+
+## Motivation
+
+- Plain text output is readable, but it becomes harder to scan as the tree grows.
+- An `(unused)` marker should stand out immediately when reading the tree.
+- React usage trees are easier to understand when component nodes and hook nodes are visually distinct.
+
+## Proposed behavior
+
+- Apply color only to human-readable ASCII output.
+- Keep `--json` output unchanged.
+- Render `(unused)` in orange anywhere it appears in the ASCII tree.
+- In `--react` mode, use one color for component nodes and another color for hook nodes.
+- Keep the tree structure characters (`├─`, `└─`, `│`) readable and avoid reducing contrast for file paths.
+- Fall back to plain text when color is unavailable or disabled.
+
+## Implementation notes
+
+- The colorization likely belongs in the tree renderers rather than the analyzers.
+- Expected touch points:
+  - `src/tree.ts`
+  - `src/react-tree.ts`
+  - a small shared color utility if we want to centralize ANSI formatting
+- We should decide whether to rely on raw ANSI sequences or add a tiny color helper dependency.
+- It would be good to respect common terminal conventions such as non-TTY output and `NO_COLOR`.
+
+## Acceptance criteria
+
+- Standard ASCII output can highlight `(unused)` in orange.
+- React ASCII output uses distinct colors for `[component]` and `[hook]` nodes.
+- `--json` output remains byte-for-byte uncolored.
+- Plain-text fallback still works when colors are disabled or unsupported.
+- Tests cover the colored output behavior without making snapshots overly brittle.
+
+## Open questions
+
+- Should color be enabled automatically only for TTY output, or should we also expose an explicit CLI flag such as `--color` / `--no-color`?
+- Should the color apply only to annotations like `[component]`, `[hook]`, and `(unused)`, or to the full node label?

--- a/src/color.ts
+++ b/src/color.ts
@@ -1,0 +1,63 @@
+import process from 'node:process'
+
+import type { ColorMode, ReactSymbolKind } from './types.js'
+
+const ANSI_RESET = '\u001B[0m'
+const ANSI_COMPONENT = '\u001B[36m'
+const ANSI_HOOK = '\u001B[35m'
+const ANSI_UNUSED = '\u001B[38;5;214m'
+
+interface ResolveColorSupportOptions {
+  readonly forceColor?: string | undefined
+  readonly isTTY?: boolean | undefined
+  readonly noColor?: string | undefined
+}
+
+export function resolveColorSupport(
+  mode: ColorMode = 'auto',
+  options: ResolveColorSupportOptions = {},
+): boolean {
+  if (mode === true) {
+    return true
+  }
+
+  if (mode === false) {
+    return false
+  }
+
+  const forceColor =
+    'forceColor' in options ? options.forceColor : process.env.FORCE_COLOR
+  if (forceColor !== undefined) {
+    return forceColor !== '0'
+  }
+
+  const noColor = 'noColor' in options ? options.noColor : process.env.NO_COLOR
+  if (noColor !== undefined) {
+    return false
+  }
+
+  const isTTY = 'isTTY' in options ? options.isTTY : process.stdout.isTTY
+  return isTTY === true
+}
+
+export function colorizeUnusedMarker(text: string, enabled: boolean): string {
+  if (!enabled) {
+    return text
+  }
+
+  return text.replaceAll('(unused)', `${ANSI_UNUSED}(unused)${ANSI_RESET}`)
+}
+
+export function formatReactSymbolLabel(
+  name: string,
+  kind: ReactSymbolKind,
+  enabled: boolean,
+): string {
+  const label = `${name} [${kind}]`
+  if (!enabled) {
+    return label
+  }
+
+  const color = kind === 'component' ? ANSI_COMPONENT : ANSI_HOOK
+  return `${color}${label}${ANSI_RESET}`
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export { printReactUsageTree } from './react-tree.js'
 export { printDependencyTree } from './tree.js'
 export type {
   AnalyzeOptions,
+  ColorMode,
   DependencyEdge,
   DependencyGraph,
   DependencyKind,

--- a/src/react-tree.ts
+++ b/src/react-tree.ts
@@ -1,3 +1,4 @@
+import { formatReactSymbolLabel, resolveColorSupport } from './color.js'
 import { toDisplayPath } from './path-utils.js'
 import { getFilteredUsages, getReactUsageRoots } from './react-analyzer.js'
 import type {
@@ -12,6 +13,7 @@ export function printReactUsageTree(
   options: PrintReactTreeOptions = {},
 ): string {
   const cwd = options.cwd ?? graph.cwd
+  const color = resolveColorSupport(options.color)
   const filter = options.filter ?? 'all'
   const roots = getReactUsageRoots(graph, filter)
 
@@ -26,7 +28,7 @@ export function printReactUsageTree(
       return
     }
 
-    lines.push(formatReactNodeLabel(root, cwd))
+    lines.push(formatReactNodeLabel(root, cwd, color))
     const usages = getFilteredUsages(root, graph, filter)
     usages.forEach((usage, usageIndex) => {
       lines.push(
@@ -35,6 +37,7 @@ export function printReactUsageTree(
           graph,
           cwd,
           filter,
+          color,
           new Set([root.id]),
           '',
           usageIndex === usages.length - 1,
@@ -55,6 +58,7 @@ function renderUsage(
   graph: ReactUsageGraph,
   cwd: string,
   filter: NonNullable<PrintReactTreeOptions['filter']>,
+  color: boolean,
   visited: ReadonlySet<string>,
   prefix: string,
   isLast: boolean,
@@ -67,10 +71,10 @@ function renderUsage(
   }
 
   if (visited.has(target.id)) {
-    return [`${branch}${formatReactNodeLabel(target, cwd)} (circular)`]
+    return [`${branch}${formatReactNodeLabel(target, cwd, color)} (circular)`]
   }
 
-  const childLines = [`${branch}${formatReactNodeLabel(target, cwd)}`]
+  const childLines = [`${branch}${formatReactNodeLabel(target, cwd, color)}`]
   const nextVisited = new Set(visited)
   nextVisited.add(target.id)
   const nextPrefix = `${prefix}${isLast ? '   ' : '│  '}`
@@ -83,6 +87,7 @@ function renderUsage(
         graph,
         cwd,
         filter,
+        color,
         nextVisited,
         nextPrefix,
         index === childUsages.length - 1,
@@ -93,6 +98,10 @@ function renderUsage(
   return childLines
 }
 
-function formatReactNodeLabel(node: ReactUsageNode, cwd: string): string {
-  return `${node.name} [${node.kind}] (${toDisplayPath(node.filePath, cwd)})`
+function formatReactNodeLabel(
+  node: ReactUsageNode,
+  cwd: string,
+  color: boolean,
+): string {
+  return `${formatReactSymbolLabel(node.name, node.kind, color)} (${toDisplayPath(node.filePath, cwd)})`
 }

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -1,3 +1,4 @@
+import { colorizeUnusedMarker, resolveColorSupport } from './color.js'
 import { toDisplayPath } from './path-utils.js'
 import type {
   DependencyEdge,
@@ -10,6 +11,7 @@ export function printDependencyTree(
   options: PrintTreeOptions = {},
 ): string {
   const cwd = options.cwd ?? graph.cwd
+  const color = resolveColorSupport(options.color)
   const includeExternals = options.includeExternals ?? false
   const omitUnused = options.omitUnused ?? false
   const rootLines = [toDisplayPath(graph.entryId, cwd)]
@@ -36,6 +38,7 @@ export function printDependencyTree(
       isLast,
       includeExternals,
       omitUnused,
+      color,
       cwd,
     )
     rootLines.push(...lines)
@@ -52,10 +55,11 @@ function renderDependency(
   isLast: boolean,
   includeExternals: boolean,
   omitUnused: boolean,
+  color: boolean,
   cwd: string,
 ): string[] {
   const branch = `${prefix}${isLast ? '└─ ' : '├─ '}`
-  const label = formatDependencyLabel(dependency, graph, cwd)
+  const label = formatDependencyLabel(dependency, cwd, color)
 
   if (dependency.kind !== 'source') {
     return [`${branch}${label}`]
@@ -92,6 +96,7 @@ function renderDependency(
         isChildLast,
         includeExternals,
         omitUnused,
+        color,
         cwd,
       ),
     )
@@ -120,8 +125,8 @@ function filterDependencies(
 
 function formatDependencyLabel(
   dependency: DependencyEdge,
-  _graph: DependencyGraph,
   cwd: string,
+  color: boolean,
 ): string {
   const prefixes: string[] = []
   if (dependency.isTypeOnly) {
@@ -141,29 +146,41 @@ function formatDependencyLabel(
   const annotation = prefixes.length > 0 ? `[${prefixes.join(', ')}] ` : ''
 
   if (dependency.kind === 'source') {
-    return withUnusedSuffix(
-      `${annotation}${toDisplayPath(dependency.target, cwd)}`,
-      dependency.unused,
+    return colorizeUnusedMarker(
+      withUnusedSuffix(
+        `${annotation}${toDisplayPath(dependency.target, cwd)}`,
+        dependency.unused,
+      ),
+      color,
     )
   }
 
   if (dependency.kind === 'missing') {
-    return withUnusedSuffix(
-      `${annotation}${dependency.specifier} [missing]`,
-      dependency.unused,
+    return colorizeUnusedMarker(
+      withUnusedSuffix(
+        `${annotation}${dependency.specifier} [missing]`,
+        dependency.unused,
+      ),
+      color,
     )
   }
 
   if (dependency.kind === 'builtin') {
-    return withUnusedSuffix(
-      `${annotation}${dependency.target} [builtin]`,
-      dependency.unused,
+    return colorizeUnusedMarker(
+      withUnusedSuffix(
+        `${annotation}${dependency.target} [builtin]`,
+        dependency.unused,
+      ),
+      color,
     )
   }
 
-  return withUnusedSuffix(
-    `${annotation}${dependency.target} [external]`,
-    dependency.unused,
+  return colorizeUnusedMarker(
+    withUnusedSuffix(
+      `${annotation}${dependency.target} [external]`,
+      dependency.unused,
+    ),
+    color,
   )
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,9 +37,12 @@ export interface PrintTreeOptions {
   readonly cwd?: string
   readonly includeExternals?: boolean
   readonly omitUnused?: boolean
+  readonly color?: ColorMode
 }
 
 export type ReactSymbolKind = 'component' | 'hook'
+
+export type ColorMode = boolean | 'auto'
 
 export type ReactUsageFilter = 'all' | ReactSymbolKind
 
@@ -68,4 +71,5 @@ export interface ReactUsageGraph {
 export interface PrintReactTreeOptions {
   readonly cwd?: string
   readonly filter?: ReactUsageFilter
+  readonly color?: ColorMode
 }

--- a/test/analyzer.test.ts
+++ b/test/analyzer.test.ts
@@ -37,7 +37,9 @@ describe('analyzeDependencies', () => {
       cwd: fixtureDirectory,
     })
 
-    const output = printDependencyTree(graph)
+    const output = printDependencyTree(graph, {
+      color: false,
+    })
 
     expect(output).toContain('src/main.ts')
     expect(output).toContain('src/app.tsx')
@@ -53,6 +55,7 @@ describe('analyzeDependencies', () => {
     })
 
     const output = printDependencyTree(graph, {
+      color: false,
       omitUnused: true,
     })
 
@@ -65,6 +68,7 @@ describe('analyzeDependencies', () => {
     })
 
     const treeOutput = printDependencyTree(graph, {
+      color: false,
       includeExternals: true,
     })
     const jsonTree = graphToSerializableTree(graph)
@@ -104,6 +108,20 @@ describe('analyzeDependencies', () => {
     expect(
       findDependencyEdgeByTarget(jsonTree, 'src/unused-helper.ts'),
     ).toBeUndefined()
+  })
+
+  it('can colorize the unused marker when requested', () => {
+    const graph = analyzeDependencies('src/main.ts', {
+      cwd: fixtureDirectory,
+    })
+
+    const output = printDependencyTree(graph, {
+      color: true,
+    })
+
+    expect(output).toContain(
+      'src/unused-helper.ts \u001B[38;5;214m(unused)\u001B[0m',
+    )
   })
 })
 

--- a/test/color.test.ts
+++ b/test/color.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  colorizeUnusedMarker,
+  formatReactSymbolLabel,
+  resolveColorSupport,
+} from '../src/color.js'
+
+describe('color helpers', () => {
+  it('can colorize the unused marker in isolation', () => {
+    expect(colorizeUnusedMarker('src/file.ts (unused)', true)).toBe(
+      'src/file.ts \u001B[38;5;214m(unused)\u001B[0m',
+    )
+    expect(colorizeUnusedMarker('src/file.ts (unused)', false)).toBe(
+      'src/file.ts (unused)',
+    )
+  })
+
+  it('uses different colors for components and hooks', () => {
+    expect(formatReactSymbolLabel('Panel', 'component', true)).toBe(
+      '\u001B[36mPanel [component]\u001B[0m',
+    )
+    expect(formatReactSymbolLabel('usePanelState', 'hook', true)).toBe(
+      '\u001B[35musePanelState [hook]\u001B[0m',
+    )
+  })
+
+  it('resolves automatic color support from terminal settings', () => {
+    expect(
+      resolveColorSupport('auto', {
+        forceColor: undefined,
+        isTTY: true,
+        noColor: undefined,
+      }),
+    ).toBe(true)
+    expect(
+      resolveColorSupport('auto', {
+        isTTY: true,
+        noColor: '1',
+      }),
+    ).toBe(false)
+    expect(
+      resolveColorSupport('auto', {
+        forceColor: '1',
+        isTTY: false,
+      }),
+    ).toBe(true)
+  })
+})

--- a/test/react-analyzer.test.ts
+++ b/test/react-analyzer.test.ts
@@ -18,7 +18,9 @@ describe('analyzeReactUsage', () => {
       cwd: fixtureDirectory,
     })
 
-    const output = printReactUsageTree(graph)
+    const output = printReactUsageTree(graph, {
+      color: false,
+    })
 
     expect(output).toContain('AppShell [component] (src/AppShell.tsx)')
     expect(output).toContain('Panel [component] (src/components/Panel.tsx)')
@@ -37,9 +39,11 @@ describe('analyzeReactUsage', () => {
     })
 
     const componentOutput = printReactUsageTree(graph, {
+      color: false,
       filter: 'component',
     })
     const hookOutput = printReactUsageTree(graph, {
+      color: false,
       filter: 'hook',
     })
 
@@ -104,5 +108,18 @@ describe('analyzeReactUsage', () => {
         }),
       ]),
     })
+  })
+
+  it('can colorize component and hook labels when requested', () => {
+    const graph = analyzeReactUsage('src/main.tsx', {
+      cwd: fixtureDirectory,
+    })
+
+    const output = printReactUsageTree(graph, {
+      color: true,
+    })
+
+    expect(output).toContain('\u001B[36mAppShell [component]\u001B[0m')
+    expect(output).toContain('\u001B[35museFeature [hook]\u001B[0m')
   })
 })


### PR DESCRIPTION
Closes #12

## Summary
- add ANSI color helpers for ASCII tree output with auto TTY and NO_COLOR handling
- colorize unused markers in the dependency tree and React component/hook labels in React mode
- document the feature and add test coverage for both colored and plain output

## Testing
- pnpm run check