### PR TITLE
feat(cli): replace --react with explicit subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@
 corepack enable
 pnpm install
 pnpm run build
-node dist/cli.mjs src/index.ts
+node dist/cli.mjs import src/index.ts
 ```
 
 ### Example
 
 ```bash
-node dist/cli.mjs src/main.ts --cwd test/fixtures/basic
+node dist/cli.mjs import src/main.ts --cwd test/fixtures/basic
 ```
 
 Output:
@@ -49,11 +49,22 @@ src/main.ts
 
 ### Options
 
+`import` command:
+
+- `foresthouse import <path>`: analyze an entry file by positional argument
+- `foresthouse import --entry <path>`: analyze an entry file by explicit option
 - `--cwd <path>`: working directory for resolving the entry file and config
 - `--config <path>`: use a specific `tsconfig.json` or `jsconfig.json`
 - `--include-externals`: include packages and Node built-ins in the output
 - `--no-unused`: omit imports that are never referenced
-- `--react[=component|hook]`: print a React usage tree instead of the import tree
+- `--json`: print a JSON tree instead of ASCII output
+
+`react` command:
+
+- `foresthouse react <path>`: print a React usage tree from an entry file
+- `--cwd <path>`: working directory for resolving the entry file and config
+- `--config <path>`: use a specific `tsconfig.json` or `jsconfig.json`
+- `--filter <component|hook>`: limit the output to a specific React symbol kind
 - `--json`: print a JSON tree instead of ASCII output
 
 ## Development

--- a/docs/issues/colorize-ascii-output.md
+++ b/docs/issues/colorize-ascii-output.md
@@ -18,7 +18,7 @@ The CLI currently prints plain ASCII trees only. We want to add terminal color t
 - Apply color only to human-readable ASCII output.
 - Keep `--json` output unchanged.
 - Render `(unused)` in orange anywhere it appears in the ASCII tree.
-- In `--react` mode, use one color for component nodes and another color for hook nodes.
+- In the `react` subcommand output, use one color for component nodes and another color for hook nodes.
 - Keep the tree structure characters (`├─`, `└─`, `│`) readable and avoid reducing contrast for file paths.
 - Fall back to plain text when color is unavailable or disabled.
 

--- a/src/app/args.ts
+++ b/src/app/args.ts
@@ -1,11 +1,21 @@
 import type { ReactUsageFilter } from '../types/react-usage-filter.js'
 
-export interface CliOptions {
+interface BaseCliOptions {
   readonly entryFile: string
   readonly cwd: string | undefined
   readonly configPath: string | undefined
+  readonly json: boolean
+}
+
+export interface ImportCliOptions extends BaseCliOptions {
+  readonly command: 'import'
   readonly includeExternals: boolean
   readonly omitUnused: boolean
-  readonly json: boolean
-  readonly react: ReactUsageFilter | undefined
 }
+
+export interface ReactCliOptions extends BaseCliOptions {
+  readonly command: 'react'
+  readonly filter: ReactUsageFilter
+}
+
+export type CliOptions = ImportCliOptions | ReactCliOptions

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -3,7 +3,7 @@ import process from 'node:process'
 import { cac } from 'cac'
 
 import type { ReactUsageFilter } from '../types/react-usage-filter.js'
-import type { CliOptions } from './args.js'
+import type { ImportCliOptions, ReactCliOptions } from './args.js'
 import { runCli } from './run.js'
 
 export function main(version: string, argv = process.argv.slice(2)): void {
@@ -18,7 +18,15 @@ class CliMain {
 
   run(): void {
     try {
-      this.createCli().parse(this.toProcessArgv())
+      const cli = this.createCli()
+
+      if (this.argv.length === 0) {
+        cli.outputHelp()
+        return
+      }
+
+      this.validateCommandSyntax()
+      cli.parse(this.toProcessArgv())
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Unknown error occurred.'
@@ -32,10 +40,11 @@ class CliMain {
 
     cli
       .command(
-        '<entry-file>',
+        'import [entry-file]',
         'Analyze an entry file and print its dependency tree.',
       )
-      .usage('<entry-file> [options]')
+      .usage('import <entry-file> [options]')
+      .option('--entry <path>', 'Entry file to analyze.')
       .option('--cwd <path>', 'Working directory used for relative paths.')
       .option(
         '--config <path>',
@@ -46,13 +55,28 @@ class CliMain {
         'Include packages and Node built-ins in the tree.',
       )
       .option('--no-unused', 'Omit imports that are never referenced.')
-      .option(
-        '--react [mode]',
-        'Print a React usage tree instead of the import tree.',
-      )
       .option('--json', 'Print the dependency tree as JSON.')
-      .action((entryFile: string, rawOptions: ParsedCliOptions) => {
-        runCli(normalizeCliOptions(entryFile, rawOptions))
+      .action(
+        (entryFile: string | undefined, rawOptions: ParsedImportCliOptions) => {
+          runCli(normalizeImportCliOptions(entryFile, rawOptions))
+        },
+      )
+
+    cli
+      .command('react <entry-file>', 'Analyze React usage from an entry file.')
+      .usage('react <entry-file> [options]')
+      .option('--cwd <path>', 'Working directory used for relative paths.')
+      .option(
+        '--config <path>',
+        'Explicit tsconfig.json or jsconfig.json path.',
+      )
+      .option(
+        '--filter <mode>',
+        'Limit output to `component` or `hook` usages.',
+      )
+      .option('--json', 'Print the React usage tree as JSON.')
+      .action((entryFile: string, rawOptions: ParsedReactCliOptions) => {
+        runCli(normalizeReactCliOptions(entryFile, rawOptions))
       })
 
     cli.help()
@@ -61,49 +85,117 @@ class CliMain {
     return cli
   }
 
+  private validateCommandSyntax(): void {
+    if (this.argv.length === 0) {
+      return
+    }
+
+    const firstArgument = this.argv[0]
+
+    if (firstArgument === undefined) {
+      return
+    }
+
+    if (firstArgument === '--react' || firstArgument.startsWith('--react=')) {
+      throw new Error('Unknown option `--react`')
+    }
+
+    if (firstArgument.startsWith('-')) {
+      return
+    }
+
+    if (firstArgument === 'import' || firstArgument === 'react') {
+      return
+    }
+
+    throw new Error(`Unknown command \`${firstArgument}\``)
+  }
+
   private toProcessArgv(): string[] {
     return ['node', 'foresthouse', ...this.argv]
   }
 }
 
-interface ParsedCliOptions {
+interface ParsedBaseCliOptions {
   readonly cwd?: string
   readonly config?: string
-  readonly includeExternals?: boolean
-  readonly unused?: boolean
   readonly json?: boolean
-  readonly react?: boolean | string
 }
 
-function normalizeCliOptions(
-  entryFile: string,
-  options: ParsedCliOptions,
-): CliOptions {
+interface ParsedImportCliOptions extends ParsedBaseCliOptions {
+  readonly entry?: string
+  readonly includeExternals?: boolean
+  readonly unused?: boolean
+}
+
+interface ParsedReactCliOptions extends ParsedBaseCliOptions {
+  readonly filter?: string
+}
+
+function normalizeImportCliOptions(
+  entryFile: string | undefined,
+  options: ParsedImportCliOptions,
+): ImportCliOptions {
   return {
-    entryFile,
+    command: 'import',
+    entryFile: resolveImportEntryFile(entryFile, options.entry),
     cwd: options.cwd,
     configPath: options.config,
     includeExternals: options.includeExternals === true,
     omitUnused: options.unused === false,
     json: options.json === true,
-    react: normalizeReactOption(options.react),
   }
 }
 
-function normalizeReactOption(
-  react: ParsedCliOptions['react'],
-): ReactUsageFilter | undefined {
-  if (react === undefined) {
-    return undefined
+function normalizeReactCliOptions(
+  entryFile: string,
+  options: ParsedReactCliOptions,
+): ReactCliOptions {
+  return {
+    command: 'react',
+    entryFile,
+    cwd: options.cwd,
+    configPath: options.config,
+    json: options.json === true,
+    filter: normalizeReactFilter(options.filter),
+  }
+}
+
+function resolveImportEntryFile(
+  positionalEntryFile: string | undefined,
+  optionEntryFile: string | undefined,
+): string {
+  if (
+    positionalEntryFile !== undefined &&
+    optionEntryFile !== undefined &&
+    positionalEntryFile !== optionEntryFile
+  ) {
+    throw new Error(
+      'Provide the import entry only once, either as `foresthouse import <entry-file>` or `foresthouse import --entry <path>`.',
+    )
   }
 
-  if (react === true) {
+  const resolvedEntryFile = positionalEntryFile ?? optionEntryFile
+
+  if (resolvedEntryFile === undefined) {
+    throw new Error(
+      'Missing import entry file. Use `foresthouse import <entry-file>` or `foresthouse import --entry <path>`.',
+    )
+  }
+
+  return resolvedEntryFile
+}
+
+function normalizeReactFilter(
+  filter: ParsedReactCliOptions['filter'],
+): ReactUsageFilter {
+  if (filter === undefined) {
     return 'all'
   }
 
-  if (react === 'component' || react === 'hook') {
-    return react
+  if (filter === 'component' || filter === 'hook') {
+    return filter
   }
 
-  throw new Error(`Unknown React mode: ${react}`)
+  throw new Error(`Unknown React filter: ${filter}`)
 }

--- a/src/app/run.ts
+++ b/src/app/run.ts
@@ -16,7 +16,7 @@ class CliApplication {
   private createCommand(): {
     run(): void
   } {
-    if (this.options.react !== undefined) {
+    if (this.options.command === 'react') {
       return new ReactCommand(this.options)
     }
 

--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -1,8 +1,11 @@
 import type { CliOptions } from '../app/args.js'
 import type { AnalyzeOptions } from '../types/analyze-options.js'
 
-export abstract class BaseCommand<TGraph> {
-  constructor(protected readonly options: CliOptions) {}
+export abstract class BaseCommand<
+  TGraph,
+  TOptions extends CliOptions = CliOptions,
+> {
+  constructor(protected readonly options: TOptions) {}
 
   run(): void {
     const graph = this.analyze()

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,10 +1,14 @@
 import { analyzeDependencies } from '../analyzers/import/index.js'
+import type { ImportCliOptions } from '../app/args.js'
 import { printDependencyTree } from '../output/ascii/import.js'
 import { graphToSerializableTree } from '../output/json/import.js'
 import type { DependencyGraph } from '../types/dependency-graph.js'
 import { BaseCommand } from './base.js'
 
-export class ImportCommand extends BaseCommand<DependencyGraph> {
+export class ImportCommand extends BaseCommand<
+  DependencyGraph,
+  ImportCliOptions
+> {
   protected analyze(): DependencyGraph {
     return analyzeDependencies(this.options.entryFile, this.getAnalyzeOptions())
   }

--- a/src/commands/react.ts
+++ b/src/commands/react.ts
@@ -1,11 +1,15 @@
 import { analyzeReactUsage } from '../analyzers/react/index.js'
+import type { ReactCliOptions } from '../app/args.js'
 import { printReactUsageTree } from '../output/ascii/react.js'
 import { graphToSerializableReactTree } from '../output/json/react.js'
 import type { ReactUsageFilter } from '../types/react-usage-filter.js'
 import type { ReactUsageGraph } from '../types/react-usage-graph.js'
 import { BaseCommand } from './base.js'
 
-export class ReactCommand extends BaseCommand<ReactUsageGraph> {
+export class ReactCommand extends BaseCommand<
+  ReactUsageGraph,
+  ReactCliOptions
+> {
   protected analyze(): ReactUsageGraph {
     return analyzeReactUsage(this.options.entryFile, this.getAnalyzeOptions())
   }
@@ -24,6 +28,6 @@ export class ReactCommand extends BaseCommand<ReactUsageGraph> {
   }
 
   private getFilter(): ReactUsageFilter {
-    return this.options.react ?? 'all'
+    return this.options.filter
   }
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -24,8 +24,9 @@ describe('main', () => {
     process.exitCode = undefined
   })
 
-  it('passes parsed options to the CLI runner', () => {
+  it('passes parsed import options to the CLI runner', () => {
     main('1.2.3', [
+      'import',
       'src/main.tsx',
       '--cwd',
       'test/fixtures/react-mode',
@@ -34,29 +35,67 @@ describe('main', () => {
       '--include-externals',
       '--no-unused',
       '--json',
-      '--react=hook',
     ])
 
     expect(runCli).toHaveBeenCalledWith({
+      command: 'import',
       entryFile: 'src/main.tsx',
       cwd: 'test/fixtures/react-mode',
       configPath: 'tsconfig.json',
       includeExternals: true,
       omitUnused: true,
       json: true,
-      react: 'hook',
     })
   })
 
-  it('treats --react without a value as all react usages', () => {
-    main('1.2.3', ['src/main.tsx', '--react'])
+  it('supports import --entry', () => {
+    main('1.2.3', ['import', '--entry', 'src/main.tsx'])
 
-    expect(runCli).toHaveBeenCalledWith(
-      expect.objectContaining({
-        entryFile: 'src/main.tsx',
-        react: 'all',
-      }),
-    )
+    expect(runCli).toHaveBeenCalledWith({
+      command: 'import',
+      entryFile: 'src/main.tsx',
+      cwd: undefined,
+      configPath: undefined,
+      includeExternals: false,
+      omitUnused: false,
+      json: false,
+    })
+  })
+
+  it('passes parsed react options to the CLI runner', () => {
+    main('1.2.3', [
+      'react',
+      'src/main.tsx',
+      '--cwd',
+      'test/fixtures/react-mode',
+      '--config',
+      'tsconfig.json',
+      '--json',
+      '--filter',
+      'hook',
+    ])
+
+    expect(runCli).toHaveBeenCalledWith({
+      command: 'react',
+      entryFile: 'src/main.tsx',
+      cwd: 'test/fixtures/react-mode',
+      configPath: 'tsconfig.json',
+      json: true,
+      filter: 'hook',
+    })
+  })
+
+  it('uses all react usages by default', () => {
+    main('1.2.3', ['react', 'src/main.tsx'])
+
+    expect(runCli).toHaveBeenCalledWith({
+      command: 'react',
+      entryFile: 'src/main.tsx',
+      cwd: undefined,
+      configPath: undefined,
+      json: false,
+      filter: 'all',
+    })
   })
 
   it('prints help through the CLI framework', () => {
@@ -65,9 +104,19 @@ describe('main', () => {
     expect(runCli).not.toHaveBeenCalled()
     expect(consoleInfo).toHaveBeenCalled()
     expect(getConsoleOutput(consoleInfo)).toContain('Usage:')
-    expect(getConsoleOutput(consoleInfo)).toContain(
-      '$ foresthouse <entry-file>',
-    )
+    expect(getConsoleOutput(consoleInfo)).toContain('$ foresthouse import')
+    expect(getConsoleOutput(consoleInfo)).toContain('$ foresthouse react')
+    expect(process.exitCode).toBeUndefined()
+  })
+
+  it('prints help when no command is provided', () => {
+    main('1.2.3', [])
+
+    expect(runCli).not.toHaveBeenCalled()
+    expect(consoleInfo).toHaveBeenCalled()
+    expect(getConsoleOutput(consoleInfo)).toContain('Usage:')
+    expect(getConsoleOutput(consoleInfo)).toContain('$ foresthouse import')
+    expect(getConsoleOutput(consoleInfo)).toContain('$ foresthouse react')
     expect(process.exitCode).toBeUndefined()
   })
 
@@ -80,7 +129,7 @@ describe('main', () => {
   })
 
   it('reports unknown options as errors', () => {
-    main('1.2.3', ['src/main.ts', '--wat'])
+    main('1.2.3', ['import', 'src/main.ts', '--wat'])
 
     expect(runCli).not.toHaveBeenCalled()
     expect(stderrWrite).toHaveBeenCalledWith(
@@ -90,7 +139,7 @@ describe('main', () => {
   })
 
   it('reports missing option values as errors', () => {
-    main('1.2.3', ['src/main.ts', '--cwd'])
+    main('1.2.3', ['import', 'src/main.ts', '--cwd'])
 
     expect(runCli).not.toHaveBeenCalled()
     expect(stderrWrite).toHaveBeenCalledWith(
@@ -99,12 +148,52 @@ describe('main', () => {
     expect(process.exitCode).toBe(1)
   })
 
-  it('reports invalid react filter values as errors', () => {
-    main('1.2.3', ['src/main.tsx', '--react=widget'])
+  it('reports a missing import entry', () => {
+    main('1.2.3', ['import'])
 
     expect(runCli).not.toHaveBeenCalled()
     expect(stderrWrite).toHaveBeenCalledWith(
-      'foresthouse: Unknown React mode: widget\n',
+      'foresthouse: Missing import entry file. Use `foresthouse import <entry-file>` or `foresthouse import --entry <path>`.\n',
+    )
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('reports conflicting import entries', () => {
+    main('1.2.3', ['import', 'src/main.ts', '--entry', 'src/app.ts'])
+
+    expect(runCli).not.toHaveBeenCalled()
+    expect(stderrWrite).toHaveBeenCalledWith(
+      'foresthouse: Provide the import entry only once, either as `foresthouse import <entry-file>` or `foresthouse import --entry <path>`.\n',
+    )
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('reports invalid react filter values as errors', () => {
+    main('1.2.3', ['react', 'src/main.tsx', '--filter', 'widget'])
+
+    expect(runCli).not.toHaveBeenCalled()
+    expect(stderrWrite).toHaveBeenCalledWith(
+      'foresthouse: Unknown React filter: widget\n',
+    )
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('rejects the removed --react flag', () => {
+    main('1.2.3', ['--react', 'src/main.tsx'])
+
+    expect(runCli).not.toHaveBeenCalled()
+    expect(stderrWrite).toHaveBeenCalledWith(
+      'foresthouse: Unknown option `--react`\n',
+    )
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('rejects the removed implicit import command form', () => {
+    main('1.2.3', ['src/main.tsx'])
+
+    expect(runCli).not.toHaveBeenCalled()
+    expect(stderrWrite).toHaveBeenCalledWith(
+      'foresthouse: Unknown command `src/main.tsx`\n',
     )
     expect(process.exitCode).toBe(1)
   })


### PR DESCRIPTION
## Summary
- replace the implicit top-level mode with explicit `import` and `react` subcommands
- support `foresthouse import --entry <path>` alongside positional entries
- update tests and docs for the new CLI behavior

## Testing
- pnpm run check

Closes #14