### PR TITLE
fix(react): preserve aliased symbol names in usage tree

### DIFF
--- a/src/analyzers/react/index.ts
+++ b/src/analyzers/react/index.ts
@@ -123,9 +123,10 @@ class ReactAnalyzer extends BaseAnalyzer<ReactUsageGraph> {
             'component',
           )
           if (targetId !== undefined && targetId !== symbol.id) {
-            usages.set(`render:${targetId}`, {
+            usages.set(`render:${targetId}:${referenceName}`, {
               kind: 'render',
               target: targetId,
+              referenceName,
             })
           }
         })
@@ -138,9 +139,10 @@ class ReactAnalyzer extends BaseAnalyzer<ReactUsageGraph> {
             'hook',
           )
           if (targetId !== undefined && targetId !== symbol.id) {
-            usages.set(`hook:${targetId}`, {
+            usages.set(`hook:${targetId}:${referenceName}`, {
               kind: 'hook-call',
               target: targetId,
+              referenceName,
             })
           }
         })
@@ -183,6 +185,7 @@ class ReactAnalyzer extends BaseAnalyzer<ReactUsageGraph> {
         const key = `${entry.location.filePath}:${entry.location.line}:${entry.location.column}:${targetId}`
         entriesByKey.set(key, {
           target: targetId,
+          referenceName: entry.referenceName,
           location: entry.location,
         })
       }

--- a/src/analyzers/react/references.ts
+++ b/src/analyzers/react/references.ts
@@ -119,6 +119,7 @@ export function compareReactUsageEntries(
     left.location.filePath.localeCompare(right.location.filePath) ||
     left.location.line - right.location.line ||
     left.location.column - right.location.column ||
+    left.referenceName.localeCompare(right.referenceName) ||
     compareReactNodeIds(left.target, right.target, nodes)
   )
 }

--- a/src/color.ts
+++ b/src/color.ts
@@ -6,6 +6,7 @@ import type { ReactSymbolKind } from './types/react-symbol-kind.js'
 const ANSI_RESET = '\u001B[0m'
 const ANSI_COMPONENT = '\u001B[36m'
 const ANSI_HOOK = '\u001B[35m'
+const ANSI_MUTED = '\u001B[38;5;244m'
 const ANSI_UNUSED = '\u001B[38;5;214m'
 
 interface ResolveColorSupportOptions {
@@ -59,6 +60,29 @@ export function formatReactSymbolLabel(
     return label
   }
 
-  const color = kind === 'component' ? ANSI_COMPONENT : ANSI_HOOK
-  return `${color}${label}${ANSI_RESET}`
+  return `${getReactSymbolColor(kind)}${label}${ANSI_RESET}`
+}
+
+export function colorizeReactLabel(
+  text: string,
+  kind: ReactSymbolKind,
+  enabled: boolean,
+): string {
+  if (!enabled) {
+    return text
+  }
+
+  return `${getReactSymbolColor(kind)}${text}${ANSI_RESET}`
+}
+
+export function colorizeMuted(text: string, enabled: boolean): string {
+  if (!enabled) {
+    return text
+  }
+
+  return `${ANSI_MUTED}${text}${ANSI_RESET}`
+}
+
+function getReactSymbolColor(kind: ReactSymbolKind): string {
+  return kind === 'component' ? ANSI_COMPONENT : ANSI_HOOK
 }

--- a/src/output/ascii/react.ts
+++ b/src/output/ascii/react.ts
@@ -3,7 +3,12 @@ import {
   getReactUsageEntries,
   getReactUsageRoots,
 } from '../../analyzers/react/queries.js'
-import { formatReactSymbolLabel, resolveColorSupport } from '../../color.js'
+import {
+  colorizeMuted,
+  colorizeReactLabel,
+  formatReactSymbolLabel,
+  resolveColorSupport,
+} from '../../color.js'
 import type { PrintReactTreeOptions } from '../../types/print-react-tree-options.js'
 import type { ReactUsageEdge } from '../../types/react-usage-edge.js'
 import type { ReactUsageEntry } from '../../types/react-usage-entry.js'
@@ -77,7 +82,7 @@ function renderReactUsageEntries(
     }
 
     lines.push(formatReactEntryLabel(entry, cwd))
-    lines.push(formatReactNodeLabel(root, cwd, color))
+    lines.push(formatReactNodeLabel(root, cwd, color, entry.referenceName))
 
     const usages = getFilteredUsages(root, graph, filter)
     usages.forEach((usage, usageIndex) => {
@@ -121,10 +126,14 @@ function renderUsage(
   }
 
   if (visited.has(target.id)) {
-    return [`${branch}${formatReactNodeLabel(target, cwd, color)} (circular)`]
+    return [
+      `${branch}${formatReactNodeLabel(target, cwd, color, usage.referenceName)} (circular)`,
+    ]
   }
 
-  const childLines = [`${branch}${formatReactNodeLabel(target, cwd, color)}`]
+  const childLines = [
+    `${branch}${formatReactNodeLabel(target, cwd, color, usage.referenceName)}`,
+  ]
   const nextVisited = new Set(visited)
   nextVisited.add(target.id)
   const nextPrefix = `${prefix}${isLast ? '   ' : '│  '}`
@@ -152,8 +161,17 @@ function formatReactNodeLabel(
   node: ReactUsageNode,
   cwd: string,
   color: boolean,
+  referenceName?: string,
 ): string {
-  return `${formatReactSymbolLabel(node.name, node.kind, color)} (${toDisplayPath(node.filePath, cwd)})`
+  const hasAlias = referenceName !== undefined && referenceName !== node.name
+  const label = hasAlias
+    ? `${colorizeReactLabel(node.name, node.kind, color)} ${colorizeMuted(
+        `as ${referenceName}`,
+        color,
+      )} ${colorizeReactLabel(`[${node.kind}]`, node.kind, color)}`
+    : formatReactSymbolLabel(node.name, node.kind, color)
+
+  return `${label} (${toDisplayPath(node.filePath, cwd)})`
 }
 
 function formatReactEntryLabel(entry: ReactUsageEntry, cwd: string): string {

--- a/src/output/json/react.ts
+++ b/src/output/json/react.ts
@@ -21,6 +21,7 @@ interface SerializedReactUsageNode {
 
 interface SerializedReactUsageEntry {
   readonly targetId: string
+  readonly referenceName: string
   readonly filePath: string
   readonly line: number
   readonly column: number
@@ -30,6 +31,7 @@ interface SerializedReactUsageEntry {
 interface SerializedReactUsageEdge {
   readonly kind: import('../../types/react-usage-edge.js').ReactUsageEdge['kind']
   readonly targetId: string
+  readonly referenceName: string
   readonly node: SerializedReactUsageNode
 }
 
@@ -100,6 +102,7 @@ function serializeReactUsageNode(
     usages: getFilteredUsages(node, graph, filter).map((usage) => ({
       kind: usage.kind,
       targetId: usage.target,
+      referenceName: usage.referenceName,
       node: serializeReactUsageNode(usage.target, graph, filter, nextVisited),
     })),
   }
@@ -112,6 +115,7 @@ function serializeReactUsageEntry(
 ): SerializedReactUsageEntry {
   return {
     targetId: entry.target,
+    referenceName: entry.referenceName,
     filePath: toDisplayPath(entry.location.filePath, graph.cwd),
     line: entry.location.line,
     column: entry.location.column,

--- a/src/types/react-usage-edge.ts
+++ b/src/types/react-usage-edge.ts
@@ -3,4 +3,5 @@ import type { ReactUsageEdgeKind } from './react-usage-edge-kind.js'
 export interface ReactUsageEdge {
   readonly kind: ReactUsageEdgeKind
   readonly target: string
+  readonly referenceName: string
 }

--- a/src/types/react-usage-entry.ts
+++ b/src/types/react-usage-entry.ts
@@ -2,5 +2,6 @@ import type { ReactUsageLocation } from './react-usage-location.js'
 
 export interface ReactUsageEntry {
   readonly target: string
+  readonly referenceName: string
   readonly location: ReactUsageLocation
 }

--- a/test/fixtures/react-mode/src/aliased-entry.tsx
+++ b/test/fixtures/react-mode/src/aliased-entry.tsx
@@ -1,0 +1,5 @@
+import { OriginalButton as AliasButton } from './components/AliasedButton'
+
+export function AliasedEntry() {
+  return <AliasButton />
+}

--- a/test/fixtures/react-mode/src/aliased-hook-entry.tsx
+++ b/test/fixtures/react-mode/src/aliased-hook-entry.tsx
@@ -1,0 +1,6 @@
+import { useFeature as useAliasedFeature } from './hooks/useFeature'
+
+export function AliasedHookEntry() {
+  useAliasedFeature()
+  return null
+}

--- a/test/fixtures/react-mode/src/components/AliasedButton.tsx
+++ b/test/fixtures/react-mode/src/components/AliasedButton.tsx
@@ -1,0 +1,3 @@
+export function OriginalButton() {
+  return <button type="button">Alias</button>
+}

--- a/test/react-analyzer.test.ts
+++ b/test/react-analyzer.test.ts
@@ -24,12 +24,16 @@ describe('analyzeReactUsage', () => {
 
     expect(output).toContain('src/main.tsx:3:7')
     expect(output).toContain('AppShell [component] (src/AppShell.tsx)')
-    expect(output).toContain('Panel [component] (src/components/Panel.tsx)')
-    expect(output).toContain('Button [component] (src/components/Button.tsx)')
+    expect(output).toContain(
+      'Panel as PrimaryPanel [component] (src/components/Panel.tsx)',
+    )
+    expect(output).toContain(
+      'Button as PrimaryButton [component] (src/components/Button.tsx)',
+    )
     expect(output).toContain('useEffect [hook] (react)')
     expect(output).toContain('useFeature [hook] (src/hooks/useFeature.ts)')
     expect(output).toContain(
-      'usePanelState [hook] (src/hooks/usePanelState.ts)',
+      'usePanelState as usePanelStateAlias [hook] (src/hooks/usePanelState.ts)',
     )
     expect(output).not.toContain('Current [component]')
   })
@@ -51,7 +55,7 @@ describe('analyzeReactUsage', () => {
     expect(componentOutput).toContain('src/main.tsx:3:7')
     expect(componentOutput).toContain('AppShell [component] (src/AppShell.tsx)')
     expect(componentOutput).toContain(
-      'Panel [component] (src/components/Panel.tsx)',
+      'Panel as PrimaryPanel [component] (src/components/Panel.tsx)',
     )
     expect(componentOutput).not.toContain('useFeature [hook]')
 
@@ -59,7 +63,7 @@ describe('analyzeReactUsage', () => {
     expect(hookOutput).toContain('useEffect [hook] (react)')
     expect(hookOutput).toContain('useFeature [hook] (src/hooks/useFeature.ts)')
     expect(hookOutput).toContain(
-      'usePanelState [hook] (src/hooks/usePanelState.ts)',
+      'usePanelState as usePanelStateAlias [hook] (src/hooks/usePanelState.ts)',
     )
     expect(hookOutput).not.toContain('AppShell [component]')
   })
@@ -99,6 +103,7 @@ describe('analyzeReactUsage', () => {
             }),
             expect.objectContaining({
               kind: 'render',
+              referenceName: 'PrimaryPanel',
               node: expect.objectContaining({
                 name: 'Panel',
                 symbolKind: 'component',
@@ -113,6 +118,7 @@ describe('analyzeReactUsage', () => {
             }),
             expect.objectContaining({
               kind: 'hook-call',
+              referenceName: 'useFeature',
               node: expect.objectContaining({
                 name: 'useFeature',
                 symbolKind: 'hook',
@@ -220,5 +226,78 @@ describe('analyzeReactUsage', () => {
 
     expect(output).toContain('\u001B[36mAppShell [component]\u001B[0m')
     expect(output).toContain('\u001B[35museFeature [hook]\u001B[0m')
+    expect(output).toContain(
+      '\u001B[36mPanel\u001B[0m \u001B[38;5;244mas PrimaryPanel\u001B[0m \u001B[36m[component]\u001B[0m',
+    )
+  })
+
+  it('shows aliased component names in tree and JSON output', () => {
+    const graph = analyzeReactUsage('src/aliased-entry.tsx', {
+      cwd: fixtureDirectory,
+    })
+
+    const output = printReactUsageTree(graph, {
+      color: false,
+      filter: 'component',
+    })
+    const jsonTree = graphToSerializableReactTree(graph, {
+      filter: 'component',
+    })
+
+    expect(output).toContain('src/aliased-entry.tsx:4:10')
+    expect(output).toContain(
+      'OriginalButton as AliasButton [component] (src/components/AliasedButton.tsx)',
+    )
+    expect(jsonTree).toMatchObject({
+      entries: [
+        expect.objectContaining({
+          referenceName: 'AliasButton',
+          node: expect.objectContaining({
+            name: 'OriginalButton',
+            symbolKind: 'component',
+          }),
+        }),
+      ],
+      roots: [
+        expect.objectContaining({
+          name: 'OriginalButton',
+        }),
+      ],
+    })
+  })
+
+  it('shows aliased hook names in tree and JSON output', () => {
+    const graph = analyzeReactUsage('src/aliased-hook-entry.tsx', {
+      cwd: fixtureDirectory,
+    })
+
+    const output = printReactUsageTree(graph, {
+      color: false,
+      filter: 'hook',
+    })
+    const jsonTree = graphToSerializableReactTree(graph, {
+      filter: 'hook',
+    })
+
+    expect(output).toContain('src/aliased-hook-entry.tsx:4:3')
+    expect(output).toContain(
+      'useFeature as useAliasedFeature [hook] (src/hooks/useFeature.ts)',
+    )
+    expect(jsonTree).toMatchObject({
+      entries: [
+        expect.objectContaining({
+          referenceName: 'useAliasedFeature',
+          node: expect.objectContaining({
+            name: 'useFeature',
+            symbolKind: 'hook',
+          }),
+        }),
+      ],
+      roots: [
+        expect.objectContaining({
+          name: 'useFeature',
+        }),
+      ],
+    })
   })
 })


### PR DESCRIPTION
## Summary
- preserve per-reference alias names on React usage entries and edges
- render aliased symbols as `Original as Alias [kind]` and mute the `as Alias` segment in ASCII output
- include alias metadata in JSON output and add coverage for aliased component and hook usage

## Testing
- pnpm exec tsc --noEmit
- pnpm vitest run test/react-analyzer.test.ts
- pnpm test

Closes #21