### PR TITLE
fix(react): normalize react entry fallback

### DIFF
--- a/src/analyzers/react/entries.ts
+++ b/src/analyzers/react/entries.ts
@@ -21,18 +21,11 @@ export function collectEntryUsages(
   program: Program,
   filePath: string,
   sourceText: string,
-  includeNestedFunctions: boolean,
 ): PendingReactUsageEntry[] {
   const entries = new Map<string, PendingReactUsageEntry>()
 
   program.body.forEach((statement) => {
-    collectStatementEntryUsages(
-      statement,
-      filePath,
-      sourceText,
-      entries,
-      includeNestedFunctions,
-    )
+    collectStatementEntryUsages(statement, filePath, sourceText, entries)
   })
 
   return [...entries.values()].sort(comparePendingReactUsageEntries)
@@ -43,16 +36,8 @@ function collectStatementEntryUsages(
   filePath: string,
   sourceText: string,
   entries: Map<string, PendingReactUsageEntry>,
-  includeNestedFunctions: boolean,
 ): void {
-  collectNodeEntryUsages(
-    statement,
-    filePath,
-    sourceText,
-    entries,
-    false,
-    includeNestedFunctions,
-  )
+  collectNodeEntryUsages(statement, filePath, sourceText, entries, false)
 }
 
 function collectNodeEntryUsages(
@@ -61,9 +46,8 @@ function collectNodeEntryUsages(
   sourceText: string,
   entries: Map<string, PendingReactUsageEntry>,
   hasComponentAncestor: boolean,
-  includeNestedFunctions: boolean,
 ): void {
-  if (!includeNestedFunctions && FUNCTION_NODE_TYPES.has(node.type)) {
+  if (FUNCTION_NODE_TYPES.has(node.type)) {
     return
   }
 
@@ -120,7 +104,6 @@ function collectNodeEntryUsages(
       sourceText,
       entries,
       nextHasComponentAncestor,
-      includeNestedFunctions,
     )
   })
 }
@@ -131,7 +114,6 @@ function collectEntryUsageChild(
   sourceText: string,
   entries: Map<string, PendingReactUsageEntry>,
   hasComponentAncestor: boolean,
-  includeNestedFunctions: boolean,
 ): void {
   if (Array.isArray(value)) {
     value.forEach((entry) => {
@@ -141,7 +123,6 @@ function collectEntryUsageChild(
         sourceText,
         entries,
         hasComponentAncestor,
-        includeNestedFunctions,
       )
     })
     return
@@ -157,7 +138,6 @@ function collectEntryUsageChild(
     sourceText,
     entries,
     hasComponentAncestor,
-    includeNestedFunctions,
   )
 }
 
@@ -175,7 +155,7 @@ function addPendingReactUsageEntry(
   })
 }
 
-function createReactUsageLocation(
+export function createReactUsageLocation(
   filePath: string,
   sourceText: string,
   offset: number,

--- a/src/analyzers/react/file.ts
+++ b/src/analyzers/react/file.ts
@@ -8,7 +8,7 @@ import type { ReactSymbolKind } from '../../types/react-symbol-kind.js'
 import type { ImportBinding } from './bindings.js'
 import { collectImportsAndExports } from './bindings.js'
 import type { PendingReactUsageEntry } from './entries.js'
-import { collectEntryUsages } from './entries.js'
+import { collectEntryUsages, createReactUsageLocation } from './entries.js'
 import { collectTopLevelReactSymbols } from './symbols.js'
 import { analyzeSymbolUsages } from './usage.js'
 
@@ -17,6 +17,7 @@ export interface PendingReactUsageNode {
   readonly name: string
   readonly kind: ReactSymbolKind
   readonly filePath: string
+  readonly declarationOffset: number
   readonly declaration: OxcFunction | ArrowFunctionExpression
   readonly exportNames: Set<string>
   readonly componentReferences: Set<string>
@@ -47,12 +48,9 @@ export function analyzeReactFile(
 
   const importsByLocalName = new Map<string, ImportBinding>()
   const exportsByName = new Map<string, string>()
-  const entryUsages = collectEntryUsages(
-    program,
-    filePath,
-    sourceText,
-    includeNestedRenderEntries,
-  )
+  const directEntryUsages = includeNestedRenderEntries
+    ? collectEntryUsages(program, filePath, sourceText)
+    : []
 
   program.body.forEach((statement) => {
     collectImportsAndExports(
@@ -68,6 +66,13 @@ export function analyzeReactFile(
     analyzeSymbolUsages(symbol)
   })
 
+  const entryUsages =
+    directEntryUsages.length > 0
+      ? directEntryUsages
+      : includeNestedRenderEntries
+        ? collectComponentDeclarationEntryUsages(symbolsByName, sourceText)
+        : []
+
   return {
     filePath,
     importsByLocalName,
@@ -78,4 +83,41 @@ export function analyzeReactFile(
     ),
     symbolsByName,
   }
+}
+
+function collectComponentDeclarationEntryUsages(
+  symbolsByName: ReadonlyMap<string, PendingReactUsageNode>,
+  sourceText: string,
+): PendingReactUsageEntry[] {
+  const componentSymbols = [...symbolsByName.values()].filter(
+    (symbol) => symbol.kind === 'component',
+  )
+  if (componentSymbols.length === 0) {
+    return []
+  }
+
+  const exportedComponentSymbols = componentSymbols.filter(
+    (symbol) => symbol.exportNames.size > 0,
+  )
+  const fallbackSymbols =
+    exportedComponentSymbols.length > 0
+      ? exportedComponentSymbols
+      : componentSymbols
+
+  return fallbackSymbols
+    .sort((left, right) => {
+      return (
+        left.declarationOffset - right.declarationOffset ||
+        left.name.localeCompare(right.name)
+      )
+    })
+    .map((symbol) => ({
+      referenceName: symbol.name,
+      kind: 'component',
+      location: createReactUsageLocation(
+        symbol.filePath,
+        sourceText,
+        symbol.declarationOffset,
+      ),
+    }))
 }

--- a/src/analyzers/react/symbols.ts
+++ b/src/analyzers/react/symbols.ts
@@ -125,6 +125,7 @@ function createPendingSymbol(
     name,
     kind,
     filePath,
+    declarationOffset: declaration.id?.start ?? declaration.start,
     declaration,
     exportNames: new Set<string>(),
     componentReferences: new Set<string>(),

--- a/test/react-analyzer.test.ts
+++ b/test/react-analyzer.test.ts
@@ -149,7 +149,7 @@ describe('analyzeReactUsage', () => {
     expect(output).toContain('<Panel /> [component] (src/components/Panel.tsx)')
   })
 
-  it('treats renders inside the entry component file as React entry locations', () => {
+  it('falls back to the entry component declaration when the file only renders inside that component', () => {
     const graph = analyzeReactUsage('src/entry-page.tsx', {
       cwd: fixtureDirectory,
     })
@@ -159,67 +159,79 @@ describe('analyzeReactUsage', () => {
       filter: 'component',
     })
 
-    expect(output).toContain('src/entry-page.tsx:7:7')
-    expect(output).toContain('src/entry-page.tsx:8:7')
+    expect(output).toContain('src/entry-page.tsx:4:25')
+    expect(output).toContain('<EntryPage /> [component] (src/entry-page.tsx)')
     expect(output).toContain('<Panel /> [component] (src/components/Panel.tsx)')
     expect(output).toContain(
       '<DynamicHost /> [component] (src/components/DynamicHost.tsx)',
     )
-    expect(output).not.toContain(
-      '<EntryPage /> [component] (src/entry-page.tsx)',
-    )
   })
 
-  it('treats hook calls inside the entry component file as React entry locations', () => {
+  it('includes hook usages under the entry component declaration fallback', () => {
     const graph = analyzeReactUsage('src/entry-hook-page.tsx', {
       cwd: fixtureDirectory,
     })
 
     const output = printReactUsageTree(graph, {
       color: false,
-      filter: 'hook',
     })
 
-    expect(output).toContain('src/entry-hook-page.tsx:7:3')
-    expect(output).toContain('src/entry-hook-page.tsx:8:3')
+    expect(output).toContain('src/entry-hook-page.tsx:6:25')
+    expect(output).toContain(
+      '<EntryHookPage /> [component] (src/entry-hook-page.tsx)',
+    )
+    expect(output).toContain('<Panel /> [component] (src/components/Panel.tsx)')
     expect(output).toContain('useEffect() [hook] (react)')
     expect(output).toContain('useFeature() [hook] (src/hooks/useFeature.ts)')
-    expect(output).not.toContain(
-      '<Panel /> [component] (src/components/Panel.tsx)',
-    )
   })
 
-  it('returns JSON entries for hook usages inside the entry component file', () => {
+  it('returns JSON entries for the entry component declaration fallback', () => {
     const graph = analyzeReactUsage('src/entry-hook-page.tsx', {
       cwd: fixtureDirectory,
     })
 
-    const jsonTree = graphToSerializableReactTree(graph, {
-      filter: 'hook',
-    })
+    const jsonTree = graphToSerializableReactTree(graph)
 
     expect(jsonTree).toMatchObject({
-      kind: 'react-usage',
-      entries: expect.arrayContaining([
+      entries: [
         expect.objectContaining({
           filePath: 'src/entry-hook-page.tsx',
-          line: 7,
-          column: 3,
+          line: 6,
+          column: 25,
           node: expect.objectContaining({
-            name: 'useEffect',
-            symbolKind: 'hook',
+            name: 'EntryHookPage',
+            symbolKind: 'component',
           }),
         }),
+      ],
+      roots: [
         expect.objectContaining({
-          filePath: 'src/entry-hook-page.tsx',
-          line: 8,
-          column: 3,
-          node: expect.objectContaining({
-            name: 'useFeature',
-            symbolKind: 'hook',
-          }),
+          name: 'EntryHookPage',
+          usages: expect.arrayContaining([
+            expect.objectContaining({
+              kind: 'render',
+              node: expect.objectContaining({
+                name: 'Panel',
+                symbolKind: 'component',
+              }),
+            }),
+            expect.objectContaining({
+              kind: 'hook-call',
+              node: expect.objectContaining({
+                name: 'useEffect',
+                symbolKind: 'hook',
+              }),
+            }),
+            expect.objectContaining({
+              kind: 'hook-call',
+              node: expect.objectContaining({
+                name: 'useFeature',
+                symbolKind: 'hook',
+              }),
+            }),
+          ]),
         }),
-      ]),
+      ],
     })
   })
 
@@ -252,23 +264,35 @@ describe('analyzeReactUsage', () => {
       filter: 'component',
     })
 
-    expect(output).toContain('src/aliased-entry.tsx:4:10')
+    expect(output).toContain('src/aliased-entry.tsx:3:17')
+    expect(output).toContain(
+      '<AliasedEntry /> [component] (src/aliased-entry.tsx)',
+    )
     expect(output).toContain(
       '<OriginalButton /> as AliasButton [component] (src/components/AliasedButton.tsx)',
     )
     expect(jsonTree).toMatchObject({
       entries: [
         expect.objectContaining({
-          referenceName: 'AliasButton',
+          referenceName: 'AliasedEntry',
           node: expect.objectContaining({
-            name: 'OriginalButton',
+            name: 'AliasedEntry',
             symbolKind: 'component',
           }),
         }),
       ],
       roots: [
         expect.objectContaining({
-          name: 'OriginalButton',
+          name: 'AliasedEntry',
+          usages: [
+            expect.objectContaining({
+              referenceName: 'AliasButton',
+              node: expect.objectContaining({
+                name: 'OriginalButton',
+                symbolKind: 'component',
+              }),
+            }),
+          ],
         }),
       ],
     })
@@ -287,23 +311,23 @@ describe('analyzeReactUsage', () => {
       filter: 'hook',
     })
 
-    expect(output).toContain('src/aliased-hook-entry.tsx:4:3')
-    expect(output).toContain(
-      'useFeature() as useAliasedFeature [hook] (src/hooks/useFeature.ts)',
-    )
+    expect(output).not.toContain('src/aliased-hook-entry.tsx:')
+    expect(output).toContain('useFeature() [hook] (src/hooks/useFeature.ts)')
     expect(jsonTree).toMatchObject({
-      entries: [
-        expect.objectContaining({
-          referenceName: 'useAliasedFeature',
-          node: expect.objectContaining({
-            name: 'useFeature',
-            symbolKind: 'hook',
-          }),
-        }),
-      ],
+      entries: [],
       roots: [
         expect.objectContaining({
           name: 'useFeature',
+          usages: [
+            expect.objectContaining({
+              kind: 'hook-call',
+              referenceName: 'usePanelStateAlias',
+              node: expect.objectContaining({
+                name: 'usePanelState',
+                symbolKind: 'hook',
+              }),
+            }),
+          ],
         }),
       ],
     })


### PR DESCRIPTION
## Summary
- normalize React entry analysis to prefer top-level direct renders in the requested entry file
- fall back to the entry component declaration when the file has no direct React node renders
- update analyzer tests to cover the declaration fallback behavior and alias cases

## Testing
- pnpm vitest run test/react-analyzer.test.ts
- pnpm exec tsc --noEmit
- pnpm exec biome check src/analyzers/react/entries.ts src/analyzers/react/file.ts src/analyzers/react/symbols.ts test/react-analyzer.test.ts