### PR TITLE
fix: ignore package tsconfig files in node_modules

### DIFF
--- a/src/typescript/config.ts
+++ b/src/typescript/config.ts
@@ -61,14 +61,16 @@ function findNearestConfig(searchFrom: string): string | undefined {
   let currentDirectory = path.resolve(searchFrom)
 
   while (true) {
-    const tsconfigPath = path.join(currentDirectory, 'tsconfig.json')
-    if (ts.sys.fileExists(tsconfigPath)) {
-      return tsconfigPath
-    }
+    if (!isInsideNodeModules(currentDirectory)) {
+      const tsconfigPath = path.join(currentDirectory, 'tsconfig.json')
+      if (ts.sys.fileExists(tsconfigPath)) {
+        return tsconfigPath
+      }
 
-    const jsconfigPath = path.join(currentDirectory, 'jsconfig.json')
-    if (ts.sys.fileExists(jsconfigPath)) {
-      return jsconfigPath
+      const jsconfigPath = path.join(currentDirectory, 'jsconfig.json')
+      if (ts.sys.fileExists(jsconfigPath)) {
+        return jsconfigPath
+      }
     }
 
     const parentDirectory = path.dirname(currentDirectory)
@@ -94,4 +96,8 @@ function defaultCompilerOptions(): ts.CompilerOptions {
 
 function formatDiagnostic(diagnostic: ts.Diagnostic): string {
   return ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
+}
+
+function isInsideNodeModules(filePath: string): boolean {
+  return filePath.includes(`${path.sep}node_modules${path.sep}`)
 }

--- a/test/analyzer.test.ts
+++ b/test/analyzer.test.ts
@@ -18,6 +18,11 @@ const monorepoFixtureDirectory = path.join(
   'packages',
   'app',
 )
+const nodeModulesConfigFixtureDirectory = path.join(
+  currentDirectory,
+  'fixtures',
+  'node-modules-config',
+)
 
 describe('analyzeDependencies', () => {
   it('resolves relative imports and tsconfig path aliases', () => {
@@ -244,6 +249,24 @@ describe('analyzeDependencies', () => {
         'index.ts',
       )} [project boundary]`,
     )
+  })
+
+  it('ignores package-internal tsconfig files under node_modules during config lookup', () => {
+    expect(() =>
+      analyzeDependencies('src/main.ts', {
+        cwd: nodeModulesConfigFixtureDirectory,
+      }),
+    ).not.toThrow()
+
+    const graph = analyzeDependencies('src/main.ts', {
+      cwd: nodeModulesConfigFixtureDirectory,
+    })
+    const output = printDependencyTree(graph, {
+      color: false,
+      includeExternals: true,
+    })
+
+    expect(output).toContain('broken-package [external]')
   })
 })
 

--- a/test/fixtures/node-modules-config/node_modules/broken-package/index.ts
+++ b/test/fixtures/node-modules-config/node_modules/broken-package/index.ts
@@ -1,0 +1,1 @@
+export const value = 1

--- a/test/fixtures/node-modules-config/node_modules/broken-package/package.json
+++ b/test/fixtures/node-modules-config/node_modules/broken-package/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "broken-package",
+  "version": "1.0.0",
+  "main": "./index.ts"
+}

--- a/test/fixtures/node-modules-config/node_modules/broken-package/tsconfig.json
+++ b/test/fixtures/node-modules-config/node_modules/broken-package/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "include": ["test/types/*.test-d.ts", "*.d.ts"]
+}

--- a/test/fixtures/node-modules-config/src/main.ts
+++ b/test/fixtures/node-modules-config/src/main.ts
@@ -1,0 +1,3 @@
+import { value } from 'broken-package'
+
+export const result = value

--- a/test/fixtures/node-modules-config/tsconfig.json
+++ b/test/fixtures/node-modules-config/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "target": "esnext"
+  }
+}


### PR DESCRIPTION
## Summary
- skip nearest-config discovery for files under `node_modules`
- add a regression fixture for packages that ship invalid package-local tsconfig inputs
- cover the failure mode with analyzer tests

## Testing
- `pnpm test -- analyzer.test.ts`

Closes #37
