### PR TITLE
feat: add builtin HTML nodes to react command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ src/main.ts
 - `foresthouse react <path>`: print a React usage tree from an entry file
 - `--cwd <path>`: working directory for resolving the entry file and config
 - `--config <path>`: use a specific `tsconfig.json` or `jsconfig.json`
-- `--filter <component|hook>`: limit the output to a specific React symbol kind
+- `--filter <component|hook|builtin>`: limit the output to a specific React symbol kind
+- `--builtin`: include built-in HTML nodes such as `button` and `div`
 - `--no-workspaces`: stop at sibling workspace package boundaries instead of expanding them
 - `--project-only`: restrict traversal to the active `tsconfig.json` or `jsconfig.json` project
 - `--json`: print a JSON tree instead of ASCII output

--- a/src/analyzers/react/entries.ts
+++ b/src/analyzers/react/entries.ts
@@ -5,6 +5,7 @@ import type { ReactSymbolKind } from '../../types/react-symbol-kind.js'
 import type { ReactUsageLocation } from '../../types/react-usage-location.js'
 import {
   FUNCTION_NODE_TYPES,
+  getBuiltinReferenceName,
   getComponentReferenceName,
   getCreateElementComponentReferenceName,
   getHookReferenceName,
@@ -21,11 +22,18 @@ export function collectEntryUsages(
   program: Program,
   filePath: string,
   sourceText: string,
+  includeBuiltins: boolean,
 ): PendingReactUsageEntry[] {
   const entries = new Map<string, PendingReactUsageEntry>()
 
   program.body.forEach((statement) => {
-    collectStatementEntryUsages(statement, filePath, sourceText, entries)
+    collectStatementEntryUsages(
+      statement,
+      filePath,
+      sourceText,
+      entries,
+      includeBuiltins,
+    )
   })
 
   return [...entries.values()].sort(comparePendingReactUsageEntries)
@@ -36,8 +44,16 @@ function collectStatementEntryUsages(
   filePath: string,
   sourceText: string,
   entries: Map<string, PendingReactUsageEntry>,
+  includeBuiltins: boolean,
 ): void {
-  collectNodeEntryUsages(statement, filePath, sourceText, entries, false)
+  collectNodeEntryUsages(
+    statement,
+    filePath,
+    sourceText,
+    entries,
+    includeBuiltins,
+    false,
+  )
 }
 
 function collectNodeEntryUsages(
@@ -45,6 +61,7 @@ function collectNodeEntryUsages(
   filePath: string,
   sourceText: string,
   entries: Map<string, PendingReactUsageEntry>,
+  includeBuiltins: boolean,
   hasComponentAncestor: boolean,
 ): void {
   if (FUNCTION_NODE_TYPES.has(node.type)) {
@@ -65,6 +82,19 @@ function collectNodeEntryUsages(
         )
       }
       nextHasComponentAncestor = true
+    } else if (includeBuiltins) {
+      const builtinName = getBuiltinReferenceName(node)
+      if (builtinName !== undefined) {
+        if (!hasComponentAncestor) {
+          addPendingReactUsageEntry(
+            entries,
+            builtinName,
+            'builtin',
+            createReactUsageLocation(filePath, sourceText, node.start),
+          )
+        }
+        nextHasComponentAncestor = true
+      }
     }
   } else if (node.type === 'CallExpression') {
     const hookReference = getHookReferenceName(node)
@@ -103,6 +133,7 @@ function collectNodeEntryUsages(
       filePath,
       sourceText,
       entries,
+      includeBuiltins,
       nextHasComponentAncestor,
     )
   })
@@ -113,6 +144,7 @@ function collectEntryUsageChild(
   filePath: string,
   sourceText: string,
   entries: Map<string, PendingReactUsageEntry>,
+  includeBuiltins: boolean,
   hasComponentAncestor: boolean,
 ): void {
   if (Array.isArray(value)) {
@@ -122,6 +154,7 @@ function collectEntryUsageChild(
         filePath,
         sourceText,
         entries,
+        includeBuiltins,
         hasComponentAncestor,
       )
     })
@@ -137,6 +170,7 @@ function collectEntryUsageChild(
     filePath,
     sourceText,
     entries,
+    includeBuiltins,
     hasComponentAncestor,
   )
 }

--- a/src/analyzers/react/file.ts
+++ b/src/analyzers/react/file.ts
@@ -22,6 +22,7 @@ export interface PendingReactUsageNode {
   readonly exportNames: Set<string>
   readonly componentReferences: Set<string>
   readonly hookReferences: Set<string>
+  readonly builtinReferences: Set<string>
 }
 
 export interface FileAnalysis {
@@ -41,6 +42,7 @@ export function analyzeReactFile(
   sourceText: string,
   includeNestedRenderEntries: boolean,
   sourceDependencies: ReadonlyMap<string, string>,
+  includeBuiltins: boolean,
 ): FileAnalysis {
   const symbolsByName = new Map<string, PendingReactUsageNode>()
 
@@ -53,7 +55,7 @@ export function analyzeReactFile(
   const reExportBindingsByName = new Map<string, ImportBinding>()
   const exportAllBindings: ImportBinding[] = []
   const directEntryUsages = includeNestedRenderEntries
-    ? collectEntryUsages(program, filePath, sourceText)
+    ? collectEntryUsages(program, filePath, sourceText, includeBuiltins)
     : []
 
   program.body.forEach((statement) => {
@@ -69,7 +71,7 @@ export function analyzeReactFile(
   })
 
   symbolsByName.forEach((symbol) => {
-    analyzeSymbolUsages(symbol)
+    analyzeSymbolUsages(symbol, includeBuiltins)
   })
 
   const entryUsages =

--- a/src/analyzers/react/index.ts
+++ b/src/analyzers/react/index.ts
@@ -13,9 +13,11 @@ import { BaseAnalyzer } from '../base.js'
 import { analyzeDependencies } from '../import/index.js'
 import { analyzeReactFile } from './file.js'
 import {
+  addBuiltinNodes,
   addExternalHookNodes,
   compareReactNodeIds,
   compareReactUsageEntries,
+  getBuiltinNodeId,
   resolveReactReference,
 } from './references.js'
 
@@ -78,6 +80,7 @@ class ReactAnalyzer extends BaseAnalyzer<ReactUsageGraph> {
           sourceText,
           filePath === dependencyGraph.entryId,
           sourceDependencies,
+          this.options.includeBuiltins === true,
         ),
       )
     }
@@ -104,6 +107,9 @@ class ReactAnalyzer extends BaseAnalyzer<ReactUsageGraph> {
     }
 
     addExternalHookNodes(fileAnalyses, nodes)
+    if (this.options.includeBuiltins === true) {
+      addBuiltinNodes(fileAnalyses, nodes)
+    }
     return nodes
   }
 
@@ -146,6 +152,17 @@ class ReactAnalyzer extends BaseAnalyzer<ReactUsageGraph> {
             })
           }
         })
+
+        if (this.options.includeBuiltins === true) {
+          symbol.builtinReferences.forEach((referenceName) => {
+            const targetId = getBuiltinNodeId(referenceName)
+            usages.set(`render:${targetId}:${referenceName}`, {
+              kind: 'render',
+              target: targetId,
+              referenceName,
+            })
+          })
+        }
 
         const node = nodes.get(symbol.id)
         if (node === undefined) {

--- a/src/analyzers/react/references.ts
+++ b/src/analyzers/react/references.ts
@@ -11,6 +11,10 @@ export function resolveReactReference(
   name: string,
   kind: ReactSymbolKind,
 ): string | undefined {
+  if (kind === 'builtin') {
+    return getBuiltinNodeId(name)
+  }
+
   const localSymbol = fileAnalysis.symbolsByName.get(name)
   if (localSymbol !== undefined && localSymbol.kind === kind) {
     return localSymbol.id
@@ -134,6 +138,33 @@ export function addExternalHookNodes(
   }
 }
 
+export function addBuiltinNodes(
+  fileAnalyses: ReadonlyMap<string, FileAnalysis>,
+  nodes: Map<string, ReactUsageNode>,
+): void {
+  for (const fileAnalysis of fileAnalyses.values()) {
+    fileAnalysis.entryUsages.forEach((entry) => {
+      if (entry.kind !== 'builtin') {
+        return
+      }
+
+      const builtinNode = createBuiltinNode(entry.referenceName)
+      if (!nodes.has(builtinNode.id)) {
+        nodes.set(builtinNode.id, builtinNode)
+      }
+    })
+
+    fileAnalysis.symbolsById.forEach((symbol) => {
+      symbol.builtinReferences.forEach((name) => {
+        const builtinNode = createBuiltinNode(name)
+        if (!nodes.has(builtinNode.id)) {
+          nodes.set(builtinNode.id, builtinNode)
+        }
+      })
+    })
+  }
+}
+
 function createExternalHookNode(
   binding: ImportBinding,
   localName: string,
@@ -150,11 +181,26 @@ function createExternalHookNode(
   }
 }
 
+function createBuiltinNode(name: string): ReactUsageNode {
+  return {
+    id: getBuiltinNodeId(name),
+    name,
+    kind: 'builtin',
+    filePath: 'html',
+    exportNames: [],
+    usages: [],
+  }
+}
+
 function getExternalHookNodeId(
   binding: ImportBinding,
   localName: string,
 ): string {
   return `external:${binding.sourceSpecifier}#hook:${getExternalHookName(binding, localName)}`
+}
+
+export function getBuiltinNodeId(name: string): string {
+  return `builtin:${name}`
 }
 
 function getExternalHookName(

--- a/src/analyzers/react/symbols.ts
+++ b/src/analyzers/react/symbols.ts
@@ -130,5 +130,6 @@ function createPendingSymbol(
     exportNames: new Set<string>(),
     componentReferences: new Set<string>(),
     hookReferences: new Set<string>(),
+    builtinReferences: new Set<string>(),
   }
 }

--- a/src/analyzers/react/usage.ts
+++ b/src/analyzers/react/usage.ts
@@ -1,12 +1,16 @@
 import type { PendingReactUsageNode } from './file.js'
 import {
+  getBuiltinReferenceName,
   getComponentReferenceName,
   getCreateElementComponentReferenceName,
   getHookReferenceName,
   walkReactUsageTree,
 } from './walk.js'
 
-export function analyzeSymbolUsages(symbol: PendingReactUsageNode): void {
+export function analyzeSymbolUsages(
+  symbol: PendingReactUsageNode,
+  includeBuiltins: boolean,
+): void {
   const root =
     symbol.declaration.type === 'ArrowFunctionExpression'
       ? symbol.declaration.body
@@ -21,6 +25,13 @@ export function analyzeSymbolUsages(symbol: PendingReactUsageNode): void {
       const name = getComponentReferenceName(node)
       if (name !== undefined) {
         symbol.componentReferences.add(name)
+      }
+
+      if (includeBuiltins) {
+        const builtinName = getBuiltinReferenceName(node)
+        if (builtinName !== undefined) {
+          symbol.builtinReferences.add(builtinName)
+        }
       }
       return
     }

--- a/src/analyzers/react/walk.ts
+++ b/src/analyzers/react/walk.ts
@@ -115,6 +115,11 @@ export function getComponentReferenceName(
   return name !== undefined && isComponentName(name) ? name : undefined
 }
 
+export function getBuiltinReferenceName(node: JSXElement): string | undefined {
+  const name = getJsxName(node.openingElement.name)
+  return name !== undefined && isIntrinsicElementName(name) ? name : undefined
+}
+
 export function getHookReferenceName(node: CallExpression): string | undefined {
   const calleeName = getIdentifierName(node.callee)
   return calleeName !== undefined && isHookName(calleeName)
@@ -143,6 +148,10 @@ export function isHookName(name: string): boolean {
 
 export function isComponentName(name: string): boolean {
   return /^[A-Z]/.test(name)
+}
+
+function isIntrinsicElementName(name: string): boolean {
+  return /^[a-z]/.test(name)
 }
 
 function returnsReactElement(

--- a/src/app/args.ts
+++ b/src/app/args.ts
@@ -18,6 +18,7 @@ export interface ImportCliOptions extends BaseCliOptions {
 export interface ReactCliOptions extends BaseCliOptions {
   readonly command: 'react'
   readonly filter: ReactUsageFilter
+  readonly includeBuiltins: boolean
 }
 
 export type CliOptions = ImportCliOptions | ReactCliOptions

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -80,8 +80,9 @@ class CliMain {
       )
       .option(
         '--filter <mode>',
-        'Limit output to `component` or `hook` usages.',
+        'Limit output to `component`, `hook`, or `builtin` usages.',
       )
+      .option('--builtin', 'Include built-in HTML nodes in the React tree.')
       .option(
         '--no-workspaces',
         'Do not expand sibling workspace packages into source subtrees.',
@@ -148,6 +149,7 @@ interface ParsedImportCliOptions extends ParsedBaseCliOptions {
 
 interface ParsedReactCliOptions extends ParsedBaseCliOptions {
   readonly filter?: string
+  readonly builtin?: boolean
 }
 
 function normalizeImportCliOptions(
@@ -180,6 +182,7 @@ function normalizeReactCliOptions(
     projectOnly: options.projectOnly === true,
     json: options.json === true,
     filter: normalizeReactFilter(options.filter),
+    includeBuiltins: options.builtin === true,
   }
 }
 
@@ -215,7 +218,7 @@ function normalizeReactFilter(
     return 'all'
   }
 
-  if (filter === 'component' || filter === 'hook') {
+  if (filter === 'component' || filter === 'hook' || filter === 'builtin') {
     return filter
   }
 

--- a/src/color.ts
+++ b/src/color.ts
@@ -6,6 +6,7 @@ import type { ReactSymbolKind } from './types/react-symbol-kind.js'
 const ANSI_RESET = '\u001B[0m'
 const ANSI_COMPONENT = '\u001B[36m'
 const ANSI_HOOK = '\u001B[35m'
+const ANSI_BUILTIN = '\u001B[34m'
 const ANSI_MUTED = '\u001B[38;5;244m'
 const ANSI_UNUSED = '\u001B[38;5;214m'
 
@@ -67,7 +68,15 @@ export function formatReactSymbolName(
   name: string,
   kind: ReactSymbolKind,
 ): string {
-  return kind === 'component' ? `<${name} />` : `${name}()`
+  if (kind === 'component') {
+    return `<${name} />`
+  }
+
+  if (kind === 'hook') {
+    return `${name}()`
+  }
+
+  return `<${name}>`
 }
 export function colorizeReactLabel(
   text: string,
@@ -90,5 +99,13 @@ export function colorizeMuted(text: string, enabled: boolean): string {
 }
 
 function getReactSymbolColor(kind: ReactSymbolKind): string {
-  return kind === 'component' ? ANSI_COMPONENT : ANSI_HOOK
+  if (kind === 'component') {
+    return ANSI_COMPONENT
+  }
+
+  if (kind === 'hook') {
+    return ANSI_HOOK
+  }
+
+  return ANSI_BUILTIN
 }

--- a/src/commands/react.ts
+++ b/src/commands/react.ts
@@ -2,6 +2,7 @@ import { analyzeReactUsage } from '../analyzers/react/index.js'
 import type { ReactCliOptions } from '../app/args.js'
 import { printReactUsageTree } from '../output/ascii/react.js'
 import { graphToSerializableReactTree } from '../output/json/react.js'
+import type { AnalyzeOptions } from '../types/analyze-options.js'
 import type { ReactUsageFilter } from '../types/react-usage-filter.js'
 import type { ReactUsageGraph } from '../types/react-usage-graph.js'
 import { BaseCommand } from './base.js'
@@ -25,6 +26,13 @@ export class ReactCommand extends BaseCommand<
       cwd: this.options.cwd ?? graph.cwd,
       filter: this.getFilter(),
     })
+  }
+
+  protected getAnalyzeOptions(): AnalyzeOptions {
+    return {
+      ...super.getAnalyzeOptions(),
+      includeBuiltins: this.options.includeBuiltins,
+    }
   }
 
   private getFilter(): ReactUsageFilter {

--- a/src/output/ascii/react.ts
+++ b/src/output/ascii/react.ts
@@ -172,9 +172,13 @@ function formatReactNodeLabel(
       )} ${colorizeReactLabel(`[${node.kind}]`, node.kind, color)}`
     : formatReactSymbolLabel(node.name, node.kind, color)
 
-  return `${label} (${toDisplayPath(node.filePath, cwd)})`
+  return `${label} (${formatReactNodeFilePath(node, cwd)})`
 }
 
 function formatReactEntryLabel(entry: ReactUsageEntry, cwd: string): string {
   return `${toDisplayPath(entry.location.filePath, cwd)}:${entry.location.line}:${entry.location.column}`
+}
+
+function formatReactNodeFilePath(node: ReactUsageNode, cwd: string): string {
+  return node.kind === 'builtin' ? 'html' : toDisplayPath(node.filePath, cwd)
 }

--- a/src/output/json/react.ts
+++ b/src/output/json/react.ts
@@ -84,7 +84,7 @@ function serializeReactUsageNode(
       id: node.id,
       name: node.name,
       symbolKind: 'circular',
-      filePath: toDisplayPath(node.filePath, graph.cwd),
+      filePath: formatReactNodeFilePath(node.filePath, node.kind, graph.cwd),
       exportNames: node.exportNames,
       usages: [],
     }
@@ -97,7 +97,7 @@ function serializeReactUsageNode(
     id: node.id,
     name: node.name,
     symbolKind: node.kind,
-    filePath: toDisplayPath(node.filePath, graph.cwd),
+    filePath: formatReactNodeFilePath(node.filePath, node.kind, graph.cwd),
     exportNames: node.exportNames,
     usages: getFilteredUsages(node, graph, filter).map((usage) => ({
       kind: usage.kind,
@@ -121,4 +121,12 @@ function serializeReactUsageEntry(
     column: entry.location.column,
     node: serializeReactUsageNode(entry.target, graph, filter, new Set()),
   }
+}
+
+function formatReactNodeFilePath(
+  filePath: string,
+  kind: import('../../types/react-symbol-kind.js').ReactSymbolKind,
+  cwd: string,
+): string {
+  return kind === 'builtin' ? 'html' : toDisplayPath(filePath, cwd)
 }

--- a/src/types/analyze-options.ts
+++ b/src/types/analyze-options.ts
@@ -3,4 +3,5 @@ export interface AnalyzeOptions {
   readonly configPath?: string
   readonly expandWorkspaces?: boolean
   readonly projectOnly?: boolean
+  readonly includeBuiltins?: boolean
 }

--- a/src/types/react-symbol-kind.ts
+++ b/src/types/react-symbol-kind.ts
@@ -1,1 +1,1 @@
-export type ReactSymbolKind = 'component' | 'hook'
+export type ReactSymbolKind = 'component' | 'hook' | 'builtin'

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -79,6 +79,7 @@ describe('main', () => {
       '--no-workspaces',
       '--project-only',
       '--json',
+      '--builtin',
       '--filter',
       'hook',
     ])
@@ -92,6 +93,7 @@ describe('main', () => {
       projectOnly: true,
       json: true,
       filter: 'hook',
+      includeBuiltins: true,
     })
   })
 
@@ -107,6 +109,7 @@ describe('main', () => {
       projectOnly: false,
       json: false,
       filter: 'all',
+      includeBuiltins: false,
     })
   })
 

--- a/test/color.test.ts
+++ b/test/color.test.ts
@@ -16,12 +16,15 @@ describe('color helpers', () => {
     )
   })
 
-  it('uses different colors for components and hooks', () => {
+  it('uses different colors for components, hooks, and builtins', () => {
     expect(formatReactSymbolLabel('Panel', 'component', true)).toBe(
       '\u001B[36m<Panel /> [component]\u001B[0m',
     )
     expect(formatReactSymbolLabel('usePanelState', 'hook', true)).toBe(
       '\u001B[35musePanelState() [hook]\u001B[0m',
+    )
+    expect(formatReactSymbolLabel('button', 'builtin', true)).toBe(
+      '\u001B[34m<button> [builtin]\u001B[0m',
     )
   })
 

--- a/test/react-analyzer.test.ts
+++ b/test/react-analyzer.test.ts
@@ -42,7 +42,59 @@ describe('analyzeReactUsage', () => {
     expect(output).toContain(
       'usePanelState() as usePanelStateAlias [hook] (src/hooks/usePanelState.ts)',
     )
+    expect(output).not.toContain('<button> [builtin] (html)')
     expect(output).not.toContain('<Current /> [component]')
+  })
+
+  it('can include built-in HTML nodes when requested', () => {
+    const graph = analyzeReactUsage('src/main.tsx', {
+      cwd: fixtureDirectory,
+      includeBuiltins: true,
+    })
+
+    const output = printReactUsageTree(graph, {
+      color: false,
+    })
+    const jsonTree = graphToSerializableReactTree(graph)
+
+    expect(output).toContain(
+      '<Button /> as PrimaryButton [component] (src/components/Button.tsx)',
+    )
+    expect(output).toContain('<button> [builtin] (html)')
+    expect(jsonTree).toMatchObject({
+      roots: expect.arrayContaining([
+        expect.objectContaining({
+          name: 'AppShell',
+          usages: expect.arrayContaining([
+            expect.objectContaining({
+              referenceName: 'PrimaryPanel',
+              node: expect.objectContaining({
+                name: 'Panel',
+                usages: expect.arrayContaining([
+                  expect.objectContaining({
+                    referenceName: 'PrimaryButton',
+                    node: expect.objectContaining({
+                      name: 'Button',
+                      usages: expect.arrayContaining([
+                        expect.objectContaining({
+                          kind: 'render',
+                          referenceName: 'button',
+                          node: expect.objectContaining({
+                            name: 'button',
+                            symbolKind: 'builtin',
+                            filePath: 'html',
+                          }),
+                        }),
+                      ]),
+                    }),
+                  }),
+                ]),
+              }),
+            }),
+          ]),
+        }),
+      ]),
+    })
   })
 
   it('can filter the tree by component or hook', () => {
@@ -245,6 +297,7 @@ describe('analyzeReactUsage', () => {
   it('can colorize component and hook labels when requested', () => {
     const graph = analyzeReactUsage('src/main.tsx', {
       cwd: fixtureDirectory,
+      includeBuiltins: true,
     })
 
     const output = printReactUsageTree(graph, {
@@ -253,6 +306,7 @@ describe('analyzeReactUsage', () => {
 
     expect(output).toContain('\u001B[36m<AppShell /> [component]\u001B[0m')
     expect(output).toContain('\u001B[35museFeature() [hook]\u001B[0m')
+    expect(output).toContain('\u001B[34m<button> [builtin]\u001B[0m')
     expect(output).toContain(
       '\u001B[36m<Panel />\u001B[0m \u001B[38;5;244mas PrimaryPanel\u001B[0m \u001B[36m[component]\u001B[0m',
     )


### PR DESCRIPTION
## Summary

- add a `--builtin` flag to `foresthouse react` and plumb it through CLI/analyzer options
- include intrinsic JSX HTML nodes in the React usage graph and render them in ASCII/JSON output
- add coverage for CLI parsing, builtin rendering/filtering, color output, and docs

## Related Issue

- Not linked yet.

## Validation

- [x] `pnpm run check`
- [x] Commits follow Conventional Commits
- [ ] Branch name follows `codex/issue-<number>-<slug>`
- [x] This PR will be Squash Merged into `dev`

## Notes

- verified CLI behavior for `react --builtin`, `react --builtin --filter builtin`, and `react --builtin --json`
- `pnpm run check` passed under Node `v20.19.0` with engine/deprecation warnings because the repo targets Node `>=24.14.0`