### PR TITLE
fix(react): include generated components in usage tree

### DIFF
--- a/src/analyzers/react/file.ts
+++ b/src/analyzers/react/file.ts
@@ -1,6 +1,8 @@
 import type {
-  ArrowFunctionExpression,
-  Function as OxcFunction,
+  Expression,
+  FunctionBody,
+  JSXElement,
+  JSXFragment,
   Program,
 } from 'oxc-parser'
 
@@ -9,7 +11,10 @@ import type { ImportBinding } from './bindings.js'
 import { collectImportsAndExports } from './bindings.js'
 import type { PendingReactUsageEntry } from './entries.js'
 import { collectEntryUsages, createReactUsageLocation } from './entries.js'
-import { collectTopLevelReactSymbols } from './symbols.js'
+import {
+  collectTopLevelDynamicComponentCandidates,
+  collectTopLevelReactSymbols,
+} from './symbols.js'
 import { analyzeSymbolUsages } from './usage.js'
 
 export interface PendingReactUsageNode {
@@ -18,7 +23,7 @@ export interface PendingReactUsageNode {
   readonly kind: ReactSymbolKind
   readonly filePath: string
   readonly declarationOffset: number
-  readonly declaration: OxcFunction | ArrowFunctionExpression
+  readonly analysisRoot: FunctionBody | Expression | JSXFragment | JSXElement
   readonly exportNames: Set<string>
   readonly componentReferences: Set<string>
   readonly hookReferences: Set<string>
@@ -32,6 +37,8 @@ export interface FileAnalysis {
   readonly reExportBindingsByName: Map<string, ImportBinding>
   readonly exportAllBindings: readonly ImportBinding[]
   readonly entryUsages: readonly PendingReactUsageEntry[]
+  readonly allSymbolsById: Map<string, PendingReactUsageNode>
+  readonly allSymbolsByName: Map<string, PendingReactUsageNode>
   readonly symbolsById: Map<string, PendingReactUsageNode>
   readonly symbolsByName: Map<string, PendingReactUsageNode>
 }
@@ -45,10 +52,27 @@ export function analyzeReactFile(
   includeBuiltins: boolean,
 ): FileAnalysis {
   const symbolsByName = new Map<string, PendingReactUsageNode>()
+  const dynamicComponentCandidatesByName = new Map<
+    string,
+    PendingReactUsageNode
+  >()
 
   program.body.forEach((statement) => {
     collectTopLevelReactSymbols(statement, filePath, symbolsByName)
   })
+  program.body.forEach((statement) => {
+    collectTopLevelDynamicComponentCandidates(
+      statement,
+      filePath,
+      symbolsByName,
+      dynamicComponentCandidatesByName,
+    )
+  })
+
+  const allSymbolsByName = new Map<string, PendingReactUsageNode>([
+    ...dynamicComponentCandidatesByName,
+    ...symbolsByName,
+  ])
 
   const importsByLocalName = new Map<string, ImportBinding>()
   const exportsByName = new Map<string, string>()
@@ -62,7 +86,7 @@ export function analyzeReactFile(
     collectImportsAndExports(
       statement,
       sourceDependencies,
-      symbolsByName,
+      allSymbolsByName,
       importsByLocalName,
       exportsByName,
       reExportBindingsByName,
@@ -70,9 +94,13 @@ export function analyzeReactFile(
     )
   })
 
-  symbolsByName.forEach((symbol) => {
+  allSymbolsByName.forEach((symbol) => {
     analyzeSymbolUsages(symbol, includeBuiltins)
   })
+
+  const allSymbolsById = new Map(
+    [...allSymbolsByName.values()].map((symbol) => [symbol.id, symbol]),
+  )
 
   const entryUsages =
     directEntryUsages.length > 0
@@ -88,6 +116,8 @@ export function analyzeReactFile(
     reExportBindingsByName,
     exportAllBindings,
     entryUsages,
+    allSymbolsById,
+    allSymbolsByName,
     symbolsById: new Map(
       [...symbolsByName.values()].map((symbol) => [symbol.id, symbol]),
     ),

--- a/src/analyzers/react/index.ts
+++ b/src/analyzers/react/index.ts
@@ -112,7 +112,7 @@ class ReactAnalyzer extends BaseAnalyzer<ReactUsageGraph> {
     const nodes = new Map<string, ReactUsageNode>()
 
     for (const fileAnalysis of fileAnalyses.values()) {
-      for (const symbol of fileAnalysis.symbolsById.values()) {
+      for (const symbol of fileAnalysis.allSymbolsById.values()) {
         nodes.set(symbol.id, {
           id: symbol.id,
           name: symbol.name,
@@ -136,7 +136,7 @@ class ReactAnalyzer extends BaseAnalyzer<ReactUsageGraph> {
     nodes: Map<string, ReactUsageNode>,
   ): void {
     for (const fileAnalysis of fileAnalyses.values()) {
-      for (const symbol of fileAnalysis.symbolsById.values()) {
+      for (const symbol of fileAnalysis.allSymbolsById.values()) {
         const usages = new Map<string, ReactUsageEdge>()
 
         symbol.componentReferences.forEach((referenceName) => {

--- a/src/analyzers/react/references.ts
+++ b/src/analyzers/react/references.ts
@@ -15,7 +15,7 @@ export function resolveReactReference(
     return getBuiltinNodeId(name)
   }
 
-  const localSymbol = fileAnalysis.symbolsByName.get(name)
+  const localSymbol = fileAnalysis.allSymbolsByName.get(name)
   if (localSymbol !== undefined && localSymbol.kind === kind) {
     return localSymbol.id
   }
@@ -66,7 +66,7 @@ function resolveExportedSymbol(
 
   const directTargetId = fileAnalysis.exportsByName.get(exportName)
   if (directTargetId !== undefined) {
-    const directTargetSymbol = fileAnalysis.symbolsById.get(directTargetId)
+    const directTargetSymbol = fileAnalysis.allSymbolsById.get(directTargetId)
     if (directTargetSymbol?.kind === kind) {
       return directTargetId
     }
@@ -154,7 +154,7 @@ export function addBuiltinNodes(
       }
     })
 
-    fileAnalysis.symbolsById.forEach((symbol) => {
+    fileAnalysis.allSymbolsById.forEach((symbol) => {
       symbol.builtinReferences.forEach((name) => {
         const builtinNode = createBuiltinNode(name)
         if (!nodes.has(builtinNode.id)) {

--- a/src/analyzers/react/symbols.ts
+++ b/src/analyzers/react/symbols.ts
@@ -1,6 +1,10 @@
 import type {
   ArrowFunctionExpression,
   ExportDefaultDeclaration,
+  Expression,
+  FunctionBody,
+  JSXElement,
+  JSXFragment,
   Function as OxcFunction,
   Statement,
   VariableDeclarator,
@@ -41,6 +45,38 @@ export function collectTopLevelReactSymbols(
   }
 }
 
+export function collectTopLevelDynamicComponentCandidates(
+  statement: Statement,
+  filePath: string,
+  symbolsByName: ReadonlyMap<string, PendingReactUsageNode>,
+  dynamicComponentCandidatesByName: Map<string, PendingReactUsageNode>,
+): void {
+  switch (statement.type) {
+    case 'VariableDeclaration':
+      statement.declarations.forEach((declarator) => {
+        addDynamicComponentCandidate(
+          declarator,
+          filePath,
+          symbolsByName,
+          dynamicComponentCandidatesByName,
+        )
+      })
+      return
+    case 'ExportNamedDeclaration':
+      if (statement.declaration !== null) {
+        collectTopLevelDynamicComponentCandidates(
+          statement.declaration,
+          filePath,
+          symbolsByName,
+          dynamicComponentCandidatesByName,
+        )
+      }
+      return
+    default:
+      return
+  }
+}
+
 function addFunctionSymbol(
   declaration: OxcFunction,
   filePath: string,
@@ -58,7 +94,13 @@ function addFunctionSymbol(
 
   symbolsByName.set(
     name,
-    createPendingSymbol(filePath, name, kind, declaration),
+    createPendingSymbol(
+      filePath,
+      name,
+      kind,
+      declaration.id?.start ?? declaration.start,
+      getAnalysisRoot(declaration),
+    ),
   )
 }
 
@@ -71,13 +113,6 @@ function addVariableSymbol(
     return
   }
 
-  if (
-    declarator.init.type !== 'ArrowFunctionExpression' &&
-    declarator.init.type !== 'FunctionExpression'
-  ) {
-    return
-  }
-
   const name = declarator.id.name
   const kind = classifyReactSymbol(name, declarator.init)
   if (kind === undefined) {
@@ -86,7 +121,13 @@ function addVariableSymbol(
 
   symbolsByName.set(
     name,
-    createPendingSymbol(filePath, name, kind, declarator.init),
+    createPendingSymbol(
+      filePath,
+      name,
+      kind,
+      declarator.init.start,
+      getAnalysisRoot(declarator.init),
+    ),
   )
 }
 
@@ -108,28 +149,100 @@ function addDefaultExportSymbol(
     if (kind !== undefined) {
       symbolsByName.set(
         name,
-        createPendingSymbol(filePath, name, kind, declaration.declaration),
+        createPendingSymbol(
+          filePath,
+          name,
+          kind,
+          declaration.declaration.start,
+          getAnalysisRoot(declaration.declaration),
+        ),
       )
     }
   }
+}
+
+function addDynamicComponentCandidate(
+  declarator: VariableDeclarator,
+  filePath: string,
+  symbolsByName: ReadonlyMap<string, PendingReactUsageNode>,
+  dynamicComponentCandidatesByName: Map<string, PendingReactUsageNode>,
+): void {
+  if (declarator.id.type !== 'Identifier' || declarator.init === null) {
+    return
+  }
+
+  const name = declarator.id.name
+  if (
+    !isPotentialDynamicComponentName(name) ||
+    symbolsByName.has(name) ||
+    !isDynamicComponentInitializer(declarator.init)
+  ) {
+    return
+  }
+
+  dynamicComponentCandidatesByName.set(
+    name,
+    createPendingSymbol(
+      filePath,
+      name,
+      'component',
+      declarator.init.start,
+      getAnalysisRoot(declarator.init),
+    ),
+  )
 }
 
 function createPendingSymbol(
   filePath: string,
   name: string,
   kind: ReactSymbolKind,
-  declaration: OxcFunction | ArrowFunctionExpression,
+  declarationOffset: number,
+  analysisRoot: FunctionBody | Expression | JSXFragment | JSXElement,
 ): PendingReactUsageNode {
   return {
     id: `${filePath}#${kind}:${name}`,
     name,
     kind,
     filePath,
-    declarationOffset: declaration.id?.start ?? declaration.start,
-    declaration,
+    declarationOffset,
+    analysisRoot,
     exportNames: new Set<string>(),
     componentReferences: new Set<string>(),
     hookReferences: new Set<string>(),
     builtinReferences: new Set<string>(),
   }
+}
+
+function getAnalysisRoot(
+  declaration: OxcFunction | ArrowFunctionExpression | Expression,
+): FunctionBody | Expression | JSXFragment | JSXElement {
+  if (
+    declaration.type === 'FunctionDeclaration' ||
+    declaration.type === 'FunctionExpression'
+  ) {
+    if (declaration.body === null) {
+      throw new Error(
+        `Expected React symbol "${declaration.id?.name ?? 'anonymous'}" to have a body.`,
+      )
+    }
+
+    return declaration.body
+  }
+
+  if (declaration.type === 'ArrowFunctionExpression') {
+    return declaration.body
+  }
+
+  return declaration
+}
+
+function isDynamicComponentInitializer(expression: Expression): boolean {
+  return (
+    expression.type === 'CallExpression' ||
+    expression.type === 'TaggedTemplateExpression'
+  )
+}
+
+function isPotentialDynamicComponentName(name: string): boolean {
+  return /^[A-Z][A-Za-z0-9]*$/.test(name)
 }

--- a/src/analyzers/react/usage.ts
+++ b/src/analyzers/react/usage.ts
@@ -4,6 +4,8 @@ import {
   getComponentReferenceName,
   getCreateElementComponentReferenceName,
   getHookReferenceName,
+  getStyledBuiltinReferenceName,
+  getStyledComponentReferenceName,
   walkReactUsageTree,
 } from './walk.js'
 
@@ -11,16 +13,7 @@ export function analyzeSymbolUsages(
   symbol: PendingReactUsageNode,
   includeBuiltins: boolean,
 ): void {
-  const root =
-    symbol.declaration.type === 'ArrowFunctionExpression'
-      ? symbol.declaration.body
-      : symbol.declaration.body
-
-  if (root === null) {
-    return
-  }
-
-  walkReactUsageTree(root, (node) => {
+  walkReactUsageTree(symbol.analysisRoot, (node) => {
     if (node.type === 'JSXElement') {
       const name = getComponentReferenceName(node)
       if (name !== undefined) {
@@ -45,6 +38,32 @@ export function analyzeSymbolUsages(
       const componentReference = getCreateElementComponentReferenceName(node)
       if (componentReference !== undefined) {
         symbol.componentReferences.add(componentReference)
+      }
+
+      const styledComponentReference = getStyledComponentReferenceName(node)
+      if (styledComponentReference !== undefined) {
+        symbol.componentReferences.add(styledComponentReference)
+      }
+
+      if (includeBuiltins) {
+        const styledBuiltinReference = getStyledBuiltinReferenceName(node)
+        if (styledBuiltinReference !== undefined) {
+          symbol.builtinReferences.add(styledBuiltinReference)
+        }
+      }
+    }
+
+    if (node.type === 'TaggedTemplateExpression') {
+      const styledComponentReference = getStyledComponentReferenceName(node)
+      if (styledComponentReference !== undefined) {
+        symbol.componentReferences.add(styledComponentReference)
+      }
+
+      if (includeBuiltins) {
+        const styledBuiltinReference = getStyledBuiltinReferenceName(node)
+        if (styledBuiltinReference !== undefined) {
+          symbol.builtinReferences.add(styledBuiltinReference)
+        }
       }
     }
   })

--- a/src/analyzers/react/walk.ts
+++ b/src/analyzers/react/walk.ts
@@ -7,6 +7,7 @@ import type {
   JSXElementName,
   JSXFragment,
   Node,
+  TaggedTemplateExpression,
 } from 'oxc-parser'
 import { visitorKeys } from 'oxc-parser'
 
@@ -77,13 +78,21 @@ export function isNode(value: unknown): value is Node {
 
 export function classifyReactSymbol(
   name: string,
-  declaration: ArrowFunctionExpression | import('oxc-parser').Function,
+  declaration:
+    | ArrowFunctionExpression
+    | import('oxc-parser').Function
+    | Expression,
 ): import('../../types/react-symbol-kind.js').ReactSymbolKind | undefined {
-  if (isHookName(name)) {
+  if (isHookName(name) && isFunctionLikeDeclaration(declaration)) {
     return 'hook'
   }
 
-  if (isComponentName(name) && returnsReactElement(declaration)) {
+  if (
+    isComponentName(name) &&
+    ((isFunctionLikeDeclaration(declaration) &&
+      returnsReactElement(declaration)) ||
+      isStyledComponentDeclaration(declaration))
+  ) {
     return 'component'
   }
 
@@ -142,6 +151,26 @@ export function getCreateElementComponentReferenceName(
   return isComponentName(firstArgument.name) ? firstArgument.name : undefined
 }
 
+export function getStyledComponentReferenceName(
+  node: CallExpression | TaggedTemplateExpression,
+): string | undefined {
+  const reference = getStyledFactoryReference(
+    node.type === 'CallExpression' ? node.callee : node.tag,
+  )
+
+  return reference?.kind === 'component' ? reference.name : undefined
+}
+
+export function getStyledBuiltinReferenceName(
+  node: CallExpression | TaggedTemplateExpression,
+): string | undefined {
+  const reference = getStyledFactoryReference(
+    node.type === 'CallExpression' ? node.callee : node.tag,
+  )
+
+  return reference?.kind === 'builtin' ? reference.name : undefined
+}
+
 export function isHookName(name: string): boolean {
   return /^use[A-Z0-9]/.test(name)
 }
@@ -152,6 +181,19 @@ export function isComponentName(name: string): boolean {
 
 function isIntrinsicElementName(name: string): boolean {
   return /^[a-z]/.test(name)
+}
+
+function isFunctionLikeDeclaration(
+  declaration:
+    | ArrowFunctionExpression
+    | import('oxc-parser').Function
+    | Expression,
+): declaration is ArrowFunctionExpression | import('oxc-parser').Function {
+  return (
+    declaration.type === 'ArrowFunctionExpression' ||
+    declaration.type === 'FunctionDeclaration' ||
+    declaration.type === 'FunctionExpression'
+  )
 }
 
 function returnsReactElement(
@@ -181,6 +223,75 @@ function returnsReactElement(
   })
 
   return found
+}
+
+function isStyledComponentDeclaration(expression: Expression): boolean {
+  if (expression.type === 'CallExpression') {
+    return getStyledFactoryReference(expression.callee) !== undefined
+  }
+
+  if (expression.type === 'TaggedTemplateExpression') {
+    return getStyledFactoryReference(expression.tag) !== undefined
+  }
+
+  return false
+}
+
+function getStyledFactoryReference(expression: Expression):
+  | {
+      readonly kind: 'builtin' | 'component'
+      readonly name: string
+    }
+  | undefined {
+  const unwrapped = unwrapExpression(expression)
+
+  if (unwrapped.type === 'MemberExpression' && !unwrapped.computed) {
+    if (
+      unwrapped.object.type !== 'Identifier' ||
+      unwrapped.object.name !== 'styled' ||
+      unwrapped.property.type !== 'Identifier'
+    ) {
+      return undefined
+    }
+
+    const name = unwrapped.property.name
+    if (isIntrinsicElementName(name)) {
+      return {
+        kind: 'builtin',
+        name,
+      }
+    }
+
+    if (isComponentName(name)) {
+      return {
+        kind: 'component',
+        name,
+      }
+    }
+
+    return undefined
+  }
+
+  if (unwrapped.type !== 'CallExpression') {
+    return undefined
+  }
+
+  const callee = unwrapExpression(unwrapped.callee)
+  if (callee.type !== 'Identifier' || callee.name !== 'styled') {
+    return undefined
+  }
+
+  const [firstArgument] = unwrapped.arguments
+  if (firstArgument?.type !== 'Identifier') {
+    return undefined
+  }
+
+  return isComponentName(firstArgument.name)
+    ? {
+        kind: 'component',
+        name: firstArgument.name,
+      }
+    : undefined
 }
 
 function isReactCreateElementCall(node: CallExpression): boolean {

--- a/test/fixtures/react-mode/src/components/BaseCard.tsx
+++ b/test/fixtures/react-mode/src/components/BaseCard.tsx
@@ -1,0 +1,7 @@
+interface BaseCardProps {
+  readonly title: string
+}
+
+export function BaseCard({ title }: BaseCardProps) {
+  return <article>{title}</article>
+}

--- a/test/fixtures/react-mode/src/components/Link.tsx
+++ b/test/fixtures/react-mode/src/components/Link.tsx
@@ -1,0 +1,8 @@
+interface LinkProps {
+  readonly href: string
+  readonly label: string
+}
+
+export function Link({ href, label }: LinkProps) {
+  return <a href={href}>{label}</a>
+}

--- a/test/fixtures/react-mode/src/styled-entry.tsx
+++ b/test/fixtures/react-mode/src/styled-entry.tsx
@@ -1,0 +1,36 @@
+import { memo } from 'react'
+import styled from 'styled-components'
+
+import { BaseCard } from './components/BaseCard'
+import { Link } from './components/Link'
+
+const Button = styled.button`
+  color: red;
+`
+
+const Card = styled(BaseCard)`
+  padding: 12px;
+`
+
+const LinkButton = styled(Link)({
+  display: 'inline-flex',
+})
+
+const Section = styled.div({
+  gap: '1rem',
+})
+
+const MemoLink = memo(function MemoLink() {
+  return <Link href="/memo" label="Memo" />
+})
+
+export function StyledEntry() {
+  return (
+    <Section>
+      <Button>Save</Button>
+      <Card title="Forest House" />
+      <LinkButton href="/docs" label="Docs" />
+      <MemoLink />
+    </Section>
+  )
+}

--- a/test/react-analyzer.test.ts
+++ b/test/react-analyzer.test.ts
@@ -193,6 +193,124 @@ describe('analyzeReactUsage', () => {
     })
   })
 
+  it('includes CSS-in-JS generated components in ASCII and JSON output', () => {
+    const graph = analyzeReactUsage('src/styled-entry.tsx', {
+      cwd: fixtureDirectory,
+      includeBuiltins: true,
+    })
+
+    const output = printReactUsageTree(graph, {
+      color: false,
+    })
+    const jsonTree = graphToSerializableReactTree(graph)
+
+    expect(output).toContain(
+      '<StyledEntry /> [component] (src/styled-entry.tsx)',
+    )
+    expect(output).toContain('<Section /> [component] (src/styled-entry.tsx)')
+    expect(output).toContain('<Button /> [component] (src/styled-entry.tsx)')
+    expect(output).toContain('<Card /> [component] (src/styled-entry.tsx)')
+    expect(output).toContain(
+      '<LinkButton /> [component] (src/styled-entry.tsx)',
+    )
+    expect(output).toContain('<MemoLink /> [component] (src/styled-entry.tsx)')
+    expect(output).toContain(
+      '<BaseCard /> [component] (src/components/BaseCard.tsx)',
+    )
+    expect(output).toContain('<Link /> [component] (src/components/Link.tsx)')
+    expect(output).toContain('<div> [builtin] (html)')
+    expect(output).toContain('<button> [builtin] (html)')
+
+    expect(jsonTree).toMatchObject({
+      entries: [
+        expect.objectContaining({
+          referenceName: 'StyledEntry',
+          node: expect.objectContaining({
+            name: 'StyledEntry',
+            symbolKind: 'component',
+          }),
+        }),
+      ],
+      roots: [
+        expect.objectContaining({
+          name: 'StyledEntry',
+          usages: expect.arrayContaining([
+            expect.objectContaining({
+              node: expect.objectContaining({
+                name: 'Section',
+                symbolKind: 'component',
+                usages: expect.arrayContaining([
+                  expect.objectContaining({
+                    node: expect.objectContaining({
+                      name: 'div',
+                      symbolKind: 'builtin',
+                    }),
+                  }),
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              node: expect.objectContaining({
+                name: 'Button',
+                symbolKind: 'component',
+                usages: expect.arrayContaining([
+                  expect.objectContaining({
+                    node: expect.objectContaining({
+                      name: 'button',
+                      symbolKind: 'builtin',
+                    }),
+                  }),
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              node: expect.objectContaining({
+                name: 'Card',
+                symbolKind: 'component',
+                usages: expect.arrayContaining([
+                  expect.objectContaining({
+                    node: expect.objectContaining({
+                      name: 'BaseCard',
+                      symbolKind: 'component',
+                    }),
+                  }),
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              node: expect.objectContaining({
+                name: 'LinkButton',
+                symbolKind: 'component',
+                usages: expect.arrayContaining([
+                  expect.objectContaining({
+                    node: expect.objectContaining({
+                      name: 'Link',
+                      symbolKind: 'component',
+                    }),
+                  }),
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              node: expect.objectContaining({
+                name: 'MemoLink',
+                symbolKind: 'component',
+                usages: expect.arrayContaining([
+                  expect.objectContaining({
+                    node: expect.objectContaining({
+                      name: 'Link',
+                      symbolKind: 'component',
+                    }),
+                  }),
+                ]),
+              }),
+            }),
+          ]),
+        }),
+      ],
+    })
+  })
+
   it('prints multiple React entry locations when the entry file renders more than one root', () => {
     const graph = analyzeReactUsage('src/multi-entry.tsx', {
       cwd: fixtureDirectory,


### PR DESCRIPTION
## Summary
- include top-level generated component declarations in the React usage graph, not just function-declared components
- keep styled factory detection for base component and intrinsic tag edges so CSS-in-JS nodes still show their relationships
- add fixture coverage for styled-components, Emotion-style calls, and memo-wrapped generated components

## Testing
- pnpm run lint
- pnpm run typecheck
- pnpm exec vitest run test/react-analyzer.test.ts

Closes #43