### PR TITLE
feat(deps): add deps command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # foresthouse
 
-`foresthouse` is a modern TypeScript-first Node.js CLI that starts from an entry file, follows local JavaScript and TypeScript imports, and prints the result as a dependency tree.
+`foresthouse` is a modern TypeScript-first Node.js CLI that can print source import trees, React usage trees, and package-manifest dependency trees.
 
 ## Stack
 
@@ -19,6 +19,7 @@
 - Resolves local imports, re-exports, `require()`, and string-literal dynamic `import()`
 - Honors the nearest `tsconfig.json` or `jsconfig.json`, including `baseUrl` and `paths`
 - Expands sibling workspace packages by default, including their own `tsconfig` alias rules
+- Reads `package.json` manifests to show package-level dependency trees for single packages and monorepos
 - Prints a tree by default, or JSON with `--json`
 - Colorizes ASCII output automatically when the terminal supports ANSI colors
 
@@ -29,6 +30,7 @@ corepack enable
 pnpm install
 pnpm run build
 node dist/cli.mjs import src/index.ts
+node dist/cli.mjs deps .
 ```
 
 ### Example
@@ -74,6 +76,13 @@ src/main.ts
 - `--no-workspaces`: stop at sibling workspace package boundaries instead of expanding them
 - `--project-only`: restrict traversal to the active `tsconfig.json` or `jsconfig.json` project
 - `--json`: print a JSON tree instead of ASCII output
+
+`deps` command:
+
+- `foresthouse deps <directory>`: analyze the nearest package rooted at the given directory
+- `foresthouse deps .`: analyze the current package or repository root
+- `foresthouse deps ./packages/a`: analyze a specific workspace package directory
+- `--json`: print a JSON package tree instead of ASCII output
 
 ## Development
 

--- a/src/analyzers/deps/index.ts
+++ b/src/analyzers/deps/index.ts
@@ -1,0 +1,499 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import type { PackageDependencyGraph } from '../../types/package-dependency-graph.js'
+import type { PackageDependencyNode } from '../../types/package-dependency-node.js'
+import type {
+  ExternalPackageManifestDependency,
+  PackageManifestDependency,
+  WorkspacePackageManifestDependency,
+} from '../../types/package-manifest-dependency.js'
+import { toDisplayPath } from '../../utils/to-display-path.js'
+import { BaseAnalyzer } from '../base.js'
+
+interface PackageManifest {
+  readonly name?: string
+  readonly workspaces?: readonly string[] | WorkspaceConfig
+  readonly dependencies?: Readonly<Record<string, string>>
+}
+
+interface WorkspaceConfig {
+  readonly packages?: readonly string[]
+}
+
+interface WorkspacePackage {
+  readonly name: string
+  readonly packageDir: string
+  readonly label: string
+}
+
+const PNPM_WORKSPACE_FILE = 'pnpm-workspace.yaml'
+
+export function analyzePackageDependencies(
+  directory: string,
+): PackageDependencyGraph {
+  return new PackageDependencyAnalyzer(directory).analyze()
+}
+
+class PackageDependencyAnalyzer extends BaseAnalyzer<PackageDependencyGraph> {
+  private readonly inputPath: string
+
+  constructor(directory: string) {
+    super(directory, {})
+    this.inputPath = path.resolve(process.cwd(), directory)
+  }
+
+  protected doAnalyze(): PackageDependencyGraph {
+    const inputDirectory = resolveInputDirectory(this.inputPath)
+    const rootPackageDir = findNearestPackageDirectory(inputDirectory)
+    const workspaceRootDir = findWorkspaceRoot(rootPackageDir) ?? rootPackageDir
+    const workspacePackages = discoverWorkspacePackages(workspaceRootDir)
+    const nodes = new Map<string, PackageDependencyNode>()
+
+    visitPackage(rootPackageDir, workspaceRootDir, workspacePackages, nodes)
+
+    return {
+      repositoryRoot: workspaceRootDir,
+      rootId: rootPackageDir,
+      nodes,
+    }
+  }
+}
+
+function visitPackage(
+  packageDir: string,
+  repositoryRoot: string,
+  workspacePackages: ReadonlyMap<string, WorkspacePackage>,
+  nodes: Map<string, PackageDependencyNode>,
+): void {
+  if (nodes.has(packageDir)) {
+    return
+  }
+
+  const manifest = readPackageManifest(packageDir)
+  const packageName = resolvePackageName(manifest, packageDir)
+  const dependencies =
+    packageDir === repositoryRoot && workspacePackages.size > 0
+      ? collectRepositoryRootDependencies(
+          manifest,
+          workspacePackages,
+          repositoryRoot,
+        )
+      : collectManifestDependencies(manifest, workspacePackages, repositoryRoot)
+
+  nodes.set(packageDir, {
+    packageDir,
+    packageName,
+    dependencies,
+  })
+
+  dependencies.forEach((dependency) => {
+    if (dependency.kind === 'workspace') {
+      visitPackage(dependency.target, repositoryRoot, workspacePackages, nodes)
+    }
+  })
+}
+
+function resolveInputDirectory(resolvedPath: string): string {
+  const stats = fs.existsSync(resolvedPath) ? fs.statSync(resolvedPath) : null
+
+  if (stats === null) {
+    throw new Error(`Directory does not exist: ${resolvedPath}`)
+  }
+
+  if (stats.isDirectory()) {
+    return resolvedPath
+  }
+
+  if (stats.isFile() && path.basename(resolvedPath) === 'package.json') {
+    return path.dirname(resolvedPath)
+  }
+
+  throw new Error(`Expected a package directory: ${resolvedPath}`)
+}
+
+function findNearestPackageDirectory(startDirectory: string): string {
+  let currentDirectory = startDirectory
+
+  while (true) {
+    const packageJsonPath = path.join(currentDirectory, 'package.json')
+    if (fs.existsSync(packageJsonPath)) {
+      return currentDirectory
+    }
+
+    const parentDirectory = path.dirname(currentDirectory)
+    if (parentDirectory === currentDirectory) {
+      break
+    }
+
+    currentDirectory = parentDirectory
+  }
+
+  throw new Error(`No package.json found from ${startDirectory}`)
+}
+
+function findWorkspaceRoot(packageDir: string): string | undefined {
+  let currentDirectory = packageDir
+
+  while (true) {
+    const packageJsonPath = path.join(currentDirectory, 'package.json')
+    if (fs.existsSync(packageJsonPath)) {
+      const manifest = readPackageManifest(currentDirectory)
+      const workspacePatterns = resolveWorkspacePatterns(
+        currentDirectory,
+        manifest,
+      )
+
+      if (workspacePatterns.length > 0 && currentDirectory === packageDir) {
+        return currentDirectory
+      }
+
+      if (
+        workspacePatterns.length > 0 &&
+        isWorkspaceMatch(currentDirectory, workspacePatterns, packageDir)
+      ) {
+        return currentDirectory
+      }
+    }
+
+    const parentDirectory = path.dirname(currentDirectory)
+    if (parentDirectory === currentDirectory) {
+      return undefined
+    }
+
+    currentDirectory = parentDirectory
+  }
+}
+
+function discoverWorkspacePackages(
+  repositoryRoot: string,
+): ReadonlyMap<string, WorkspacePackage> {
+  const manifest = readPackageManifest(repositoryRoot)
+  const workspacePatterns = resolveWorkspacePatterns(repositoryRoot, manifest)
+
+  if (workspacePatterns.length === 0) {
+    return new Map()
+  }
+
+  const workspacePackageDirs = new Set<string>()
+
+  workspacePatterns.forEach((pattern) => {
+    expandWorkspacePattern(repositoryRoot, pattern).forEach((packageDir) => {
+      workspacePackageDirs.add(packageDir)
+    })
+  })
+
+  const workspacePackages = new Map<string, WorkspacePackage>()
+
+  Array.from(workspacePackageDirs)
+    .sort((left, right) => left.localeCompare(right))
+    .forEach((packageDir) => {
+      const workspaceManifest = readPackageManifest(packageDir)
+      const workspaceName = resolvePackageName(workspaceManifest, packageDir)
+
+      if (workspacePackages.has(workspaceName)) {
+        throw new Error(`Duplicate workspace package name: ${workspaceName}`)
+      }
+
+      workspacePackages.set(workspaceName, {
+        name: workspaceName,
+        packageDir,
+        label: toDisplayPath(packageDir, repositoryRoot),
+      })
+    })
+
+  return workspacePackages
+}
+
+function collectManifestDependencies(
+  manifest: PackageManifest,
+  workspacePackages: ReadonlyMap<string, WorkspacePackage>,
+  repositoryRoot: string,
+): readonly PackageManifestDependency[] {
+  const dependencyEntries = Object.entries(manifest.dependencies ?? {})
+  const workspaceDependencies: WorkspacePackageManifestDependency[] = []
+  const externalDependencies: ExternalPackageManifestDependency[] = []
+
+  dependencyEntries.forEach(([dependencyName, specifier]) => {
+    const workspacePackage = workspacePackages.get(dependencyName)
+
+    if (workspacePackage !== undefined) {
+      workspaceDependencies.push({
+        kind: 'workspace',
+        name: dependencyName,
+        specifier,
+        target: workspacePackage.packageDir,
+      })
+      return
+    }
+
+    externalDependencies.push({
+      kind: 'external',
+      name: dependencyName,
+      specifier,
+    })
+  })
+
+  workspaceDependencies.sort((left, right) => {
+    const leftLabel = toDisplayPath(left.target, repositoryRoot)
+    const rightLabel = toDisplayPath(right.target, repositoryRoot)
+    return leftLabel.localeCompare(rightLabel)
+  })
+  externalDependencies.sort((left, right) =>
+    left.name.localeCompare(right.name),
+  )
+
+  return [...workspaceDependencies, ...externalDependencies]
+}
+
+function collectRepositoryRootDependencies(
+  manifest: PackageManifest,
+  workspacePackages: ReadonlyMap<string, WorkspacePackage>,
+  _repositoryRoot: string,
+): readonly PackageManifestDependency[] {
+  const topLevelWorkspaceDependencies = Array.from(workspacePackages.values())
+    .sort((left, right) => left.label.localeCompare(right.label))
+    .map<WorkspacePackageManifestDependency>((workspacePackage) => ({
+      kind: 'workspace',
+      name: workspacePackage.name,
+      target: workspacePackage.packageDir,
+    }))
+
+  const externalDependencies = Object.entries(manifest.dependencies ?? {})
+    .filter(([dependencyName]) => !workspacePackages.has(dependencyName))
+    .map<ExternalPackageManifestDependency>(([dependencyName, specifier]) => ({
+      kind: 'external',
+      name: dependencyName,
+      specifier,
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name))
+
+  return [...topLevelWorkspaceDependencies, ...externalDependencies]
+}
+
+function readPackageManifest(packageDir: string): PackageManifest {
+  const packageJsonPath = path.join(packageDir, 'package.json')
+
+  if (!fs.existsSync(packageJsonPath)) {
+    throw new Error(`Missing package.json in ${packageDir}`)
+  }
+
+  const manifestText = fs.readFileSync(packageJsonPath, 'utf8')
+
+  try {
+    const parsed = JSON.parse(manifestText) as unknown
+
+    if (!isRecord(parsed)) {
+      throw new Error('package.json must contain an object')
+    }
+
+    return parsed as PackageManifest
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unknown JSON parse error'
+    throw new Error(`Failed to read ${packageJsonPath}: ${message}`)
+  }
+}
+
+function resolvePackageName(
+  manifest: PackageManifest,
+  packageDir: string,
+): string {
+  if (typeof manifest.name === 'string' && manifest.name.trim().length > 0) {
+    return manifest.name
+  }
+
+  throw new Error(`Package at ${packageDir} is missing a valid name`)
+}
+
+function getWorkspacePatterns(manifest: PackageManifest): readonly string[] {
+  if (Array.isArray(manifest.workspaces)) {
+    return manifest.workspaces.filter(
+      (pattern): pattern is string =>
+        typeof pattern === 'string' && pattern.length > 0,
+    )
+  }
+
+  if (
+    isRecord(manifest.workspaces) &&
+    Array.isArray(manifest.workspaces.packages)
+  ) {
+    return manifest.workspaces.packages.filter(
+      (pattern): pattern is string =>
+        typeof pattern === 'string' && pattern.length > 0,
+    )
+  }
+
+  return []
+}
+
+function resolveWorkspacePatterns(
+  repositoryRoot: string,
+  manifest: PackageManifest,
+): readonly string[] {
+  const manifestPatterns = getWorkspacePatterns(manifest)
+  if (manifestPatterns.length > 0) {
+    return manifestPatterns
+  }
+
+  return readPnpmWorkspacePatterns(repositoryRoot)
+}
+
+function readPnpmWorkspacePatterns(repositoryRoot: string): readonly string[] {
+  const pnpmWorkspacePath = path.join(repositoryRoot, PNPM_WORKSPACE_FILE)
+
+  if (!fs.existsSync(pnpmWorkspacePath)) {
+    return []
+  }
+
+  const fileContent = fs.readFileSync(pnpmWorkspacePath, 'utf8')
+  const lines = fileContent.split(/\r?\n/)
+  const patterns: string[] = []
+  let inPackagesBlock = false
+
+  for (const line of lines) {
+    const trimmedLine = line.trim()
+
+    if (trimmedLine.length === 0 || trimmedLine.startsWith('#')) {
+      continue
+    }
+
+    if (!inPackagesBlock) {
+      if (trimmedLine === 'packages:') {
+        inPackagesBlock = true
+      }
+
+      continue
+    }
+
+    if (!line.startsWith(' ') && !line.startsWith('\t')) {
+      break
+    }
+
+    if (!trimmedLine.startsWith('- ')) {
+      continue
+    }
+
+    const pattern = unquoteWorkspacePattern(trimmedLine.slice(2).trim())
+
+    if (pattern.length > 0) {
+      patterns.push(pattern)
+    }
+  }
+
+  return patterns
+}
+
+function unquoteWorkspacePattern(pattern: string): string {
+  if (
+    (pattern.startsWith('"') && pattern.endsWith('"')) ||
+    (pattern.startsWith("'") && pattern.endsWith("'"))
+  ) {
+    return pattern.slice(1, -1)
+  }
+
+  return pattern
+}
+
+function isWorkspaceMatch(
+  repositoryRoot: string,
+  patterns: readonly string[],
+  packageDir: string,
+): boolean {
+  return patterns.some((pattern) =>
+    expandWorkspacePattern(repositoryRoot, pattern).includes(packageDir),
+  )
+}
+
+function expandWorkspacePattern(
+  repositoryRoot: string,
+  pattern: string,
+): string[] {
+  const segments = normalizeWorkspacePattern(pattern)
+  const matches = matchWorkspaceSegments(repositoryRoot, segments, 0)
+
+  return matches.filter((packageDir) =>
+    fs.existsSync(path.join(packageDir, 'package.json')),
+  )
+}
+
+function normalizeWorkspacePattern(pattern: string): string[] {
+  return pattern
+    .split(/[\\/]+/)
+    .filter((segment) => segment.length > 0 && segment !== '.')
+}
+
+function matchWorkspaceSegments(
+  currentDirectory: string,
+  segments: readonly string[],
+  index: number,
+): string[] {
+  if (index >= segments.length) {
+    return [currentDirectory]
+  }
+
+  const segment = segments[index]
+  if (segment === undefined) {
+    return [currentDirectory]
+  }
+
+  if (segment === '**') {
+    const results = new Set<string>(
+      matchWorkspaceSegments(currentDirectory, segments, index + 1),
+    )
+
+    listSubdirectories(currentDirectory).forEach((subdirectory) => {
+      matchWorkspaceSegments(subdirectory, segments, index).forEach((match) => {
+        results.add(match)
+      })
+    })
+
+    return [...results]
+  }
+
+  const matcher = createWorkspaceSegmentMatcher(segment)
+  const results: string[] = []
+
+  listSubdirectories(currentDirectory).forEach((subdirectory) => {
+    if (!matcher(path.basename(subdirectory))) {
+      return
+    }
+
+    results.push(...matchWorkspaceSegments(subdirectory, segments, index + 1))
+  })
+
+  return results
+}
+
+function listSubdirectories(directory: string): string[] {
+  return fs
+    .readdirSync(directory, { withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isDirectory() &&
+        entry.name !== 'node_modules' &&
+        entry.name !== '.git',
+    )
+    .map((entry) => path.join(directory, entry.name))
+}
+
+function createWorkspaceSegmentMatcher(
+  segment: string,
+): (name: string) => boolean {
+  if (!segment.includes('*')) {
+    return (name: string) => name === segment
+  }
+
+  const escapedSegment = escapeRegExp(segment).replaceAll('*', '[^/]*')
+  const pattern = new RegExp(`^${escapedSegment}$`)
+
+  return (name: string) => pattern.test(name)
+}
+
+function escapeRegExp(value: string): string {
+  return value.replaceAll(/[|\\{}()[\]^$+?.]/g, '\\$&')
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}

--- a/src/app/args.ts
+++ b/src/app/args.ts
@@ -15,6 +15,11 @@ export interface ImportCliOptions extends BaseCliOptions {
   readonly omitUnused: boolean
 }
 
+export interface DepsCliOptions extends BaseCliOptions {
+  readonly command: 'deps'
+  readonly directory: string
+}
+
 export interface ReactCliOptions extends BaseCliOptions {
   readonly command: 'react'
   readonly entryFile: string | undefined
@@ -23,4 +28,4 @@ export interface ReactCliOptions extends BaseCliOptions {
   readonly includeBuiltins: boolean
 }
 
-export type CliOptions = ImportCliOptions | ReactCliOptions
+export type CliOptions = DepsCliOptions | ImportCliOptions | ReactCliOptions

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -3,7 +3,11 @@ import process from 'node:process'
 import { cac } from 'cac'
 
 import type { ReactUsageFilter } from '../types/react-usage-filter.js'
-import type { ImportCliOptions, ReactCliOptions } from './args.js'
+import type {
+  DepsCliOptions,
+  ImportCliOptions,
+  ReactCliOptions,
+} from './args.js'
 import { runCli } from './run.js'
 
 export function main(version: string, argv = process.argv.slice(2)): void {
@@ -37,6 +41,17 @@ class CliMain {
 
   private createCli() {
     const cli = cac('foresthouse')
+
+    cli
+      .command(
+        'deps <directory>',
+        'Analyze package.json dependencies from a package directory.',
+      )
+      .usage('deps <directory> [options]')
+      .option('--json', 'Print the package tree as JSON.')
+      .action((directory: string, rawOptions: ParsedDepsCliOptions) => {
+        runCli(normalizeDepsCliOptions(directory, rawOptions))
+      })
 
     cli
       .command(
@@ -127,7 +142,11 @@ class CliMain {
       return
     }
 
-    if (firstArgument === 'import' || firstArgument === 'react') {
+    if (
+      firstArgument === 'deps' ||
+      firstArgument === 'import' ||
+      firstArgument === 'react'
+    ) {
       return
     }
 
@@ -147,6 +166,10 @@ interface ParsedBaseCliOptions {
   readonly json?: boolean
 }
 
+interface ParsedDepsCliOptions {
+  readonly json?: boolean
+}
+
 interface ParsedImportCliOptions extends ParsedBaseCliOptions {
   readonly entry?: string
   readonly includeExternals?: boolean
@@ -157,6 +180,21 @@ interface ParsedReactCliOptions extends ParsedBaseCliOptions {
   readonly filter?: string
   readonly nextjs?: boolean
   readonly builtin?: boolean
+}
+
+function normalizeDepsCliOptions(
+  directory: string,
+  options: ParsedDepsCliOptions,
+): DepsCliOptions {
+  return {
+    command: 'deps',
+    directory,
+    cwd: undefined,
+    configPath: undefined,
+    expandWorkspaces: true,
+    projectOnly: false,
+    json: options.json === true,
+  }
 }
 
 function normalizeImportCliOptions(

--- a/src/app/run.ts
+++ b/src/app/run.ts
@@ -1,3 +1,4 @@
+import { DepsCommand } from '../commands/deps.js'
 import { ImportCommand } from '../commands/import.js'
 import { ReactCommand } from '../commands/react.js'
 import type { CliOptions } from './args.js'
@@ -16,6 +17,10 @@ class CliApplication {
   private createCommand(): {
     run(): void
   } {
+    if (this.options.command === 'deps') {
+      return new DepsCommand(this.options)
+    }
+
     if (this.options.command === 'react') {
       return new ReactCommand(this.options)
     }

--- a/src/commands/deps.ts
+++ b/src/commands/deps.ts
@@ -1,0 +1,23 @@
+import { analyzePackageDependencies } from '../analyzers/deps/index.js'
+import type { DepsCliOptions } from '../app/args.js'
+import { printPackageDependencyTree } from '../output/ascii/deps.js'
+import { graphToSerializablePackageTree } from '../output/json/deps.js'
+import type { PackageDependencyGraph } from '../types/package-dependency-graph.js'
+import { BaseCommand } from './base.js'
+
+export class DepsCommand extends BaseCommand<
+  PackageDependencyGraph,
+  DepsCliOptions
+> {
+  protected analyze(): PackageDependencyGraph {
+    return analyzePackageDependencies(this.options.directory)
+  }
+
+  protected serialize(graph: PackageDependencyGraph): object {
+    return graphToSerializablePackageTree(graph)
+  }
+
+  protected render(graph: PackageDependencyGraph): string {
+    return printPackageDependencyTree(graph)
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { analyzePackageDependencies } from './analyzers/deps/index.js'
 export { analyzeDependencies } from './analyzers/import/index.js'
 export { analyzeReactUsage } from './analyzers/react/index.js'
 export {
@@ -5,8 +6,10 @@ export {
   getReactUsageEntries,
   getReactUsageRoots,
 } from './analyzers/react/queries.js'
+export { printPackageDependencyTree } from './output/ascii/deps.js'
 export { printDependencyTree } from './output/ascii/import.js'
 export { printReactUsageTree } from './output/ascii/react.js'
+export { graphToSerializablePackageTree } from './output/json/deps.js'
 export { graphToSerializableTree } from './output/json/import.js'
 export { graphToSerializableReactTree } from './output/json/react.js'
 export type { AnalyzeOptions } from './types/analyze-options.js'
@@ -14,6 +17,10 @@ export type { ColorMode } from './types/color-mode.js'
 export type { DependencyEdge } from './types/dependency-edge.js'
 export type { DependencyGraph } from './types/dependency-graph.js'
 export type { DependencyKind } from './types/dependency-kind.js'
+export type { PackageDependencyGraph } from './types/package-dependency-graph.js'
+export type { PackageDependencyNode } from './types/package-dependency-node.js'
+export type { PackageManifestDependency } from './types/package-manifest-dependency.js'
+export type { PrintPackageTreeOptions } from './types/print-package-tree-options.js'
 export type { PrintReactTreeOptions } from './types/print-react-tree-options.js'
 export type { PrintTreeOptions } from './types/print-tree-options.js'
 export type { ReactSymbolKind } from './types/react-symbol-kind.js'

--- a/src/output/ascii/deps.ts
+++ b/src/output/ascii/deps.ts
@@ -1,0 +1,91 @@
+import type { PackageDependencyGraph } from '../../types/package-dependency-graph.js'
+import type { PackageManifestDependency } from '../../types/package-manifest-dependency.js'
+import type { PrintPackageTreeOptions } from '../../types/print-package-tree-options.js'
+import { toDisplayPath } from '../../utils/to-display-path.js'
+
+export function printPackageDependencyTree(
+  graph: PackageDependencyGraph,
+  _options: PrintPackageTreeOptions = {},
+): string {
+  const rootNode = graph.nodes.get(graph.rootId)
+  if (rootNode === undefined) {
+    return toDisplayPath(graph.rootId, graph.repositoryRoot)
+  }
+
+  const lines = [rootNode.packageName]
+  const visited = new Set<string>([graph.rootId])
+
+  rootNode.dependencies.forEach((dependency, index) => {
+    lines.push(
+      ...renderDependency(
+        dependency,
+        graph,
+        visited,
+        '',
+        index === rootNode.dependencies.length - 1,
+      ),
+    )
+  })
+
+  return lines.join('\n')
+}
+
+function renderDependency(
+  dependency: PackageManifestDependency,
+  graph: PackageDependencyGraph,
+  visited: ReadonlySet<string>,
+  prefix: string,
+  isLast: boolean,
+): string[] {
+  const branch = `${prefix}${isLast ? '└─ ' : '├─ '}`
+  const label = formatDependencyLabel(dependency, graph.repositoryRoot)
+
+  if (dependency.kind === 'external') {
+    return [`${branch}${label}`]
+  }
+
+  if (visited.has(dependency.target)) {
+    return [`${branch}${label} (circular)`]
+  }
+
+  const childNode = graph.nodes.get(dependency.target)
+  if (childNode === undefined) {
+    return [`${branch}${label}`]
+  }
+
+  const childLines = [`${branch}${label}`]
+  const nextPrefix = `${prefix}${isLast ? '   ' : '│  '}`
+  const nextVisited = new Set(visited)
+  nextVisited.add(dependency.target)
+
+  childNode.dependencies.forEach((childDependency, index) => {
+    childLines.push(
+      ...renderDependency(
+        childDependency,
+        graph,
+        nextVisited,
+        nextPrefix,
+        index === childNode.dependencies.length - 1,
+      ),
+    )
+  })
+
+  return childLines
+}
+
+function formatDependencyLabel(
+  dependency: PackageManifestDependency,
+  repositoryRoot: string,
+): string {
+  if (dependency.kind === 'external') {
+    return `${dependency.name}@${dependency.specifier}`
+  }
+
+  const workspaceLabel = toDisplayPath(dependency.target, repositoryRoot)
+
+  if (dependency.specifier === undefined) {
+    return workspaceLabel
+  }
+
+  return `${workspaceLabel} (${dependency.specifier})`
+}

--- a/src/output/json/deps.ts
+++ b/src/output/json/deps.ts
@@ -1,0 +1,74 @@
+import type { PackageDependencyGraph } from '../../types/package-dependency-graph.js'
+import type { PackageManifestDependency } from '../../types/package-manifest-dependency.js'
+import { toDisplayPath } from '../../utils/to-display-path.js'
+
+export function graphToSerializablePackageTree(
+  graph: PackageDependencyGraph,
+): object {
+  return serializePackageNode(graph.rootId, graph, new Set())
+}
+
+function serializePackageNode(
+  packageDir: string,
+  graph: PackageDependencyGraph,
+  visited: Set<string>,
+): object {
+  const packageNode = graph.nodes.get(packageDir)
+  const packagePath = toDisplayPath(packageDir, graph.repositoryRoot)
+
+  if (packageNode === undefined) {
+    return {
+      kind: 'missing',
+      label: packagePath,
+      path: packagePath,
+      dependencies: [],
+    }
+  }
+
+  if (visited.has(packageDir)) {
+    return {
+      kind: 'circular',
+      label: packageNode.packageName,
+      packageName: packageNode.packageName,
+      path: packagePath,
+      dependencies: [],
+    }
+  }
+
+  visited.add(packageDir)
+
+  return {
+    kind: packageDir === graph.rootId ? 'root' : 'workspace',
+    label: packageDir === graph.rootId ? packageNode.packageName : packagePath,
+    packageName: packageNode.packageName,
+    path: packagePath,
+    dependencies: packageNode.dependencies.map((dependency) =>
+      serializeDependency(dependency, graph, new Set(visited)),
+    ),
+  }
+}
+
+function serializeDependency(
+  dependency: PackageManifestDependency,
+  graph: PackageDependencyGraph,
+  visited: Set<string>,
+): object {
+  if (dependency.kind === 'external') {
+    return {
+      kind: 'external',
+      name: dependency.name,
+      specifier: dependency.specifier,
+      target: `${dependency.name}@${dependency.specifier}`,
+    }
+  }
+
+  return {
+    kind: 'workspace',
+    name: dependency.name,
+    ...(dependency.specifier === undefined
+      ? {}
+      : { specifier: dependency.specifier }),
+    target: toDisplayPath(dependency.target, graph.repositoryRoot),
+    node: serializePackageNode(dependency.target, graph, visited),
+  }
+}

--- a/src/types/package-dependency-graph.ts
+++ b/src/types/package-dependency-graph.ts
@@ -1,0 +1,7 @@
+import type { PackageDependencyNode } from './package-dependency-node.js'
+
+export interface PackageDependencyGraph {
+  readonly repositoryRoot: string
+  readonly rootId: string
+  readonly nodes: ReadonlyMap<string, PackageDependencyNode>
+}

--- a/src/types/package-dependency-node.ts
+++ b/src/types/package-dependency-node.ts
@@ -1,0 +1,7 @@
+import type { PackageManifestDependency } from './package-manifest-dependency.js'
+
+export interface PackageDependencyNode {
+  readonly packageDir: string
+  readonly packageName: string
+  readonly dependencies: readonly PackageManifestDependency[]
+}

--- a/src/types/package-manifest-dependency.ts
+++ b/src/types/package-manifest-dependency.ts
@@ -1,0 +1,16 @@
+export interface ExternalPackageManifestDependency {
+  readonly kind: 'external'
+  readonly name: string
+  readonly specifier: string
+}
+
+export interface WorkspacePackageManifestDependency {
+  readonly kind: 'workspace'
+  readonly name: string
+  readonly specifier?: string
+  readonly target: string
+}
+
+export type PackageManifestDependency =
+  | ExternalPackageManifestDependency
+  | WorkspacePackageManifestDependency

--- a/src/types/print-package-tree-options.ts
+++ b/src/types/print-package-tree-options.ts
@@ -1,0 +1,5 @@
+import type { ColorMode } from './color-mode.js'
+
+export interface PrintPackageTreeOptions {
+  readonly color?: ColorMode
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -52,6 +52,20 @@ describe('main', () => {
     })
   })
 
+  it('passes parsed deps options to the CLI runner', () => {
+    main('1.2.3', ['deps', './packages/app', '--json'])
+
+    expect(runCli).toHaveBeenCalledWith({
+      command: 'deps',
+      directory: './packages/app',
+      cwd: undefined,
+      configPath: undefined,
+      expandWorkspaces: true,
+      projectOnly: false,
+      json: true,
+    })
+  })
+
   it('supports import --entry', () => {
     main('1.2.3', ['import', '--entry', 'src/main.tsx'])
 
@@ -155,6 +169,7 @@ describe('main', () => {
     expect(runCli).not.toHaveBeenCalled()
     expect(consoleInfo).toHaveBeenCalled()
     expect(getConsoleOutput(consoleInfo)).toContain('Usage:')
+    expect(getConsoleOutput(consoleInfo)).toContain('$ foresthouse deps')
     expect(getConsoleOutput(consoleInfo)).toContain('$ foresthouse import')
     expect(getConsoleOutput(consoleInfo)).toContain('$ foresthouse react')
     expect(process.exitCode).toBeUndefined()
@@ -166,6 +181,7 @@ describe('main', () => {
     expect(runCli).not.toHaveBeenCalled()
     expect(consoleInfo).toHaveBeenCalled()
     expect(getConsoleOutput(consoleInfo)).toContain('Usage:')
+    expect(getConsoleOutput(consoleInfo)).toContain('$ foresthouse deps')
     expect(getConsoleOutput(consoleInfo)).toContain('$ foresthouse import')
     expect(getConsoleOutput(consoleInfo)).toContain('$ foresthouse react')
     expect(process.exitCode).toBeUndefined()
@@ -195,6 +211,16 @@ describe('main', () => {
     expect(runCli).not.toHaveBeenCalled()
     expect(stderrWrite).toHaveBeenCalledWith(
       'foresthouse: option `--cwd <path>` value is missing\n',
+    )
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('rejects deps --cwd because the directory must be positional', () => {
+    main('1.2.3', ['deps', '.', '--cwd', 'packages'])
+
+    expect(runCli).not.toHaveBeenCalled()
+    expect(stderrWrite).toHaveBeenCalledWith(
+      'foresthouse: Unknown option `--cwd`\n',
     )
     expect(process.exitCode).toBe(1)
   })

--- a/test/deps-analyzer.test.ts
+++ b/test/deps-analyzer.test.ts
@@ -1,0 +1,246 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  analyzePackageDependencies,
+  graphToSerializablePackageTree,
+  printPackageDependencyTree,
+} from '../src/index.js'
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url))
+const singleFixtureDirectory = path.join(
+  currentDirectory,
+  'fixtures',
+  'deps-single',
+)
+const monorepoFixtureDirectory = path.join(
+  currentDirectory,
+  'fixtures',
+  'deps-monorepo',
+)
+const pnpmMonorepoFixtureDirectory = path.join(
+  currentDirectory,
+  'fixtures',
+  'deps-pnpm-monorepo',
+)
+
+describe('analyzePackageDependencies', () => {
+  it('prints a single-package dependency tree with declared version specifiers', () => {
+    const graph = analyzePackageDependencies(singleFixtureDirectory)
+    const output = printPackageDependencyTree(graph, {
+      color: false,
+    })
+    const jsonTree = graphToSerializablePackageTree(graph)
+
+    expect(output).toBe(
+      [
+        'single-package-fixture',
+        '├─ react@^19.1.1',
+        '├─ tsup@^8.5.0',
+        '└─ zod@^3.25.0',
+      ].join('\n'),
+    )
+    expect(jsonTree).toMatchObject({
+      kind: 'root',
+      label: 'single-package-fixture',
+      packageName: 'single-package-fixture',
+      path: '.',
+      dependencies: [
+        {
+          kind: 'external',
+          name: 'react',
+          specifier: '^19.1.1',
+          target: 'react@^19.1.1',
+        },
+        {
+          kind: 'external',
+          name: 'tsup',
+          specifier: '^8.5.0',
+          target: 'tsup@^8.5.0',
+        },
+        {
+          kind: 'external',
+          name: 'zod',
+          specifier: '^3.25.0',
+          target: 'zod@^3.25.0',
+        },
+      ],
+    })
+  })
+
+  it('expands internal workspace packages from a monorepo root', () => {
+    const graph = analyzePackageDependencies(monorepoFixtureDirectory)
+    const output = printPackageDependencyTree(graph, {
+      color: false,
+    })
+    const jsonTree = graphToSerializablePackageTree(graph)
+
+    expect(output).toBe(
+      [
+        'deps-monorepo-root',
+        '├─ apps/web',
+        '│  ├─ packages/ui (workspace:*)',
+        '│  │  ├─ packages/config (workspace:*)',
+        '│  │  │  └─ zod@^3.25.0',
+        '│  │  └─ clsx@^2.1.1',
+        '│  └─ react@^19.1.1',
+        '├─ packages/config',
+        '│  └─ zod@^3.25.0',
+        '├─ packages/ui',
+        '│  ├─ packages/config (workspace:*)',
+        '│  │  └─ zod@^3.25.0',
+        '│  └─ clsx@^2.1.1',
+        '└─ typescript@^5.9.3',
+      ].join('\n'),
+    )
+    expect(jsonTree).toMatchObject({
+      kind: 'root',
+      label: 'deps-monorepo-root',
+      packageName: 'deps-monorepo-root',
+      path: '.',
+      dependencies: [
+        {
+          kind: 'workspace',
+          name: '@repo/web',
+          target: 'apps/web',
+          node: {
+            kind: 'workspace',
+            label: 'apps/web',
+            packageName: '@repo/web',
+            dependencies: [
+              expect.objectContaining({
+                kind: 'workspace',
+                target: 'packages/ui',
+              }),
+              expect.objectContaining({
+                kind: 'external',
+                target: 'react@^19.1.1',
+              }),
+            ],
+          },
+        },
+        {
+          kind: 'workspace',
+          name: '@repo/config',
+          target: 'packages/config',
+        },
+        {
+          kind: 'workspace',
+          name: '@repo/ui',
+          target: 'packages/ui',
+        },
+        {
+          kind: 'external',
+          name: 'typescript',
+          specifier: '^5.9.3',
+          target: 'typescript@^5.9.3',
+        },
+      ],
+    })
+  })
+
+  it('can analyze a workspace package directory while still resolving sibling workspaces', () => {
+    const graph = analyzePackageDependencies(
+      path.join(monorepoFixtureDirectory, 'apps', 'web'),
+    )
+    const output = printPackageDependencyTree(graph, {
+      color: false,
+    })
+    const jsonTree = graphToSerializablePackageTree(graph)
+
+    expect(output).toBe(
+      [
+        '@repo/web',
+        '├─ packages/ui (workspace:*)',
+        '│  ├─ packages/config (workspace:*)',
+        '│  │  └─ zod@^3.25.0',
+        '│  └─ clsx@^2.1.1',
+        '└─ react@^19.1.1',
+      ].join('\n'),
+    )
+    expect(jsonTree).toMatchObject({
+      kind: 'root',
+      label: '@repo/web',
+      packageName: '@repo/web',
+      path: 'apps/web',
+      dependencies: [
+        {
+          kind: 'workspace',
+          target: 'packages/ui',
+          node: {
+            kind: 'workspace',
+            label: 'packages/ui',
+            path: 'packages/ui',
+            dependencies: [
+              expect.objectContaining({
+                kind: 'workspace',
+                target: 'packages/config',
+              }),
+              expect.objectContaining({
+                kind: 'external',
+                target: 'clsx@^2.1.1',
+              }),
+            ],
+          },
+        },
+        {
+          kind: 'external',
+          target: 'react@^19.1.1',
+        },
+      ],
+    })
+  })
+
+  it('discovers monorepo workspaces from pnpm-workspace.yaml', () => {
+    const graph = analyzePackageDependencies(pnpmMonorepoFixtureDirectory)
+    const output = printPackageDependencyTree(graph, {
+      color: false,
+    })
+    const jsonTree = graphToSerializablePackageTree(graph)
+
+    expect(output).toBe(
+      [
+        'deps-pnpm-monorepo-root',
+        '├─ apps/web',
+        '│  ├─ packages/ui (workspace:*)',
+        '│  │  ├─ packages/config (workspace:*)',
+        '│  │  │  └─ zod@^3.25.0',
+        '│  │  └─ clsx@^2.1.1',
+        '│  └─ react@^19.1.1',
+        '├─ packages/config',
+        '│  └─ zod@^3.25.0',
+        '├─ packages/ui',
+        '│  ├─ packages/config (workspace:*)',
+        '│  │  └─ zod@^3.25.0',
+        '│  └─ clsx@^2.1.1',
+        '└─ typescript@^5.9.3',
+      ].join('\n'),
+    )
+    expect(jsonTree).toMatchObject({
+      kind: 'root',
+      label: 'deps-pnpm-monorepo-root',
+      packageName: 'deps-pnpm-monorepo-root',
+      path: '.',
+      dependencies: [
+        expect.objectContaining({
+          kind: 'workspace',
+          target: 'apps/web',
+        }),
+        expect.objectContaining({
+          kind: 'workspace',
+          target: 'packages/config',
+        }),
+        expect.objectContaining({
+          kind: 'workspace',
+          target: 'packages/ui',
+        }),
+        expect.objectContaining({
+          kind: 'external',
+          target: 'typescript@^5.9.3',
+        }),
+      ],
+    })
+  })
+})

--- a/test/fixtures/deps-monorepo/apps/web/package.json
+++ b/test/fixtures/deps-monorepo/apps/web/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@repo/web",
+  "private": true,
+  "dependencies": {
+    "@repo/ui": "workspace:*",
+    "react": "^19.1.1"
+  }
+}

--- a/test/fixtures/deps-monorepo/package.json
+++ b/test/fixtures/deps-monorepo/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "deps-monorepo-root",
+  "private": true,
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "dependencies": {
+    "@repo/ui": "workspace:*",
+    "@repo/web": "workspace:*",
+    "typescript": "^5.9.3"
+  }
+}

--- a/test/fixtures/deps-monorepo/packages/config/package.json
+++ b/test/fixtures/deps-monorepo/packages/config/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@repo/config",
+  "private": true,
+  "dependencies": {
+    "zod": "^3.25.0"
+  }
+}

--- a/test/fixtures/deps-monorepo/packages/ui/package.json
+++ b/test/fixtures/deps-monorepo/packages/ui/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@repo/ui",
+  "private": true,
+  "dependencies": {
+    "@repo/config": "workspace:*",
+    "clsx": "^2.1.1"
+  }
+}

--- a/test/fixtures/deps-pnpm-monorepo/apps/web/package.json
+++ b/test/fixtures/deps-pnpm-monorepo/apps/web/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@repo/web",
+  "private": true,
+  "dependencies": {
+    "@repo/ui": "workspace:*",
+    "react": "^19.1.1"
+  }
+}

--- a/test/fixtures/deps-pnpm-monorepo/package.json
+++ b/test/fixtures/deps-pnpm-monorepo/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "deps-pnpm-monorepo-root",
+  "private": true,
+  "dependencies": {
+    "@repo/ui": "workspace:*",
+    "@repo/web": "workspace:*",
+    "typescript": "^5.9.3"
+  }
+}

--- a/test/fixtures/deps-pnpm-monorepo/packages/config/package.json
+++ b/test/fixtures/deps-pnpm-monorepo/packages/config/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@repo/config",
+  "private": true,
+  "dependencies": {
+    "zod": "^3.25.0"
+  }
+}

--- a/test/fixtures/deps-pnpm-monorepo/packages/ui/package.json
+++ b/test/fixtures/deps-pnpm-monorepo/packages/ui/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@repo/ui",
+  "private": true,
+  "dependencies": {
+    "@repo/config": "workspace:*",
+    "clsx": "^2.1.1"
+  }
+}

--- a/test/fixtures/deps-pnpm-monorepo/pnpm-workspace.yaml
+++ b/test/fixtures/deps-pnpm-monorepo/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - apps/*
+  - packages/*

--- a/test/fixtures/deps-single/package.json
+++ b/test/fixtures/deps-single/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "single-package-fixture",
+  "private": true,
+  "dependencies": {
+    "react": "^19.1.1",
+    "tsup": "^8.5.0",
+    "zod": "^3.25.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `deps` CLI command with ASCII and JSON output for package-manifest dependency trees
- analyze single-package repos plus monorepos, including workspace expansion from `package.json#workspaces` and `pnpm-workspace.yaml`
- add fixtures, analyzer coverage, and CLI tests for single-package, package.json workspace, and pnpm workspace cases

## Testing
- pnpm run check

Closes #40
