### PR TITLE
feat(deps): use pnpm lockfile data for deps diff

### DIFF
--- a/src/analyzers/deps/diff.ts
+++ b/src/analyzers/deps/diff.ts
@@ -13,6 +13,10 @@ import type { PackageDependencyGraph } from '../../types/package-dependency-grap
 import type { PackageManifestDependency } from '../../types/package-manifest-dependency.js'
 import { toDisplayPath } from '../../utils/to-display-path.js'
 import { analyzePackageDependencies } from './index.js'
+import {
+  loadPnpmLockImporterResolutions,
+  type PnpmLockDependencyResolution,
+} from './pnpm-lock.js'
 
 interface GitDiffComparison {
   readonly beforeTree: string
@@ -35,6 +39,8 @@ interface ComparableExternalPackageDependency {
   readonly key: string
   readonly name: string
   readonly specifier: string
+  readonly resolvedVersion?: string
+  readonly peerContext?: string
 }
 
 interface ComparableWorkspacePackageDependency {
@@ -49,6 +55,7 @@ type ComparablePackageDependency =
   | ComparableExternalPackageDependency
   | ComparableWorkspacePackageDependency
 
+const PNPM_LOCKFILE = 'pnpm-lock.yaml'
 const PNPM_WORKSPACE_FILE = 'pnpm-workspace.yaml'
 
 export function analyzePackageDependencyDiff(
@@ -320,7 +327,11 @@ function ensureSnapshotDirectory(snapshotRoot: string, filePath: string): void {
 
 function isManifestSnapshotFile(filePath: string): boolean {
   const fileName = path.posix.basename(filePath)
-  return fileName === 'package.json' || fileName === PNPM_WORKSPACE_FILE
+  return (
+    fileName === 'package.json' ||
+    fileName === PNPM_LOCKFILE ||
+    fileName === PNPM_WORKSPACE_FILE
+  )
 }
 
 function resolveSnapshotInputPath(
@@ -358,16 +369,24 @@ function tryAnalyzePackageGraph(
 function toComparableGraph(
   graph: PackageDependencyGraph,
 ): ComparablePackageDependencyGraph {
+  const pnpmLockResolutions = loadPnpmLockImporterResolutions(
+    graph.repositoryRoot,
+  )
   const nodes = new Map<string, ComparablePackageDependencyNode>()
 
   graph.nodes.forEach((node, packageDir) => {
     const packagePath = toDisplayPath(packageDir, graph.repositoryRoot)
+    const packageLockResolutions = pnpmLockResolutions?.get(packagePath)
     const dependenciesByKey = new Map<string, ComparablePackageDependency>()
 
     node.dependencies.forEach((dependency) => {
       dependenciesByKey.set(
         createDependencyKey(dependency),
-        toComparableDependency(dependency, graph.repositoryRoot),
+        toComparableDependency(
+          dependency,
+          graph.repositoryRoot,
+          packageLockResolutions?.get(dependency.name),
+        ),
       )
     })
 
@@ -391,13 +410,19 @@ function createDependencyKey(dependency: PackageManifestDependency): string {
 function toComparableDependency(
   dependency: PackageManifestDependency,
   repositoryRoot: string,
+  lockResolution: PnpmLockDependencyResolution | undefined,
 ): ComparablePackageDependency {
   if (dependency.kind === 'external') {
+    const resolvedVersion = resolveResolvedVersion(lockResolution)
+    const peerContext = resolvePeerContext(lockResolution)
+
     return {
       kind: 'external',
       key: createDependencyKey(dependency),
       name: dependency.name,
       specifier: dependency.specifier,
+      ...(resolvedVersion === undefined ? {} : { resolvedVersion }),
+      ...(peerContext === undefined ? {} : { peerContext }),
     }
   }
 
@@ -408,6 +433,38 @@ function toComparableDependency(
     specifier: dependency.specifier,
     targetPath: toDisplayPath(dependency.target, repositoryRoot),
   }
+}
+
+function resolveResolvedVersion(
+  lockResolution: PnpmLockDependencyResolution | undefined,
+): string | undefined {
+  if (lockResolution === undefined) {
+    return undefined
+  }
+
+  const version = lockResolution.version?.trim()
+
+  if (
+    version === undefined ||
+    version.length === 0 ||
+    version.startsWith('link:') ||
+    version.startsWith('file:') ||
+    version.startsWith('workspace:')
+  ) {
+    return undefined
+  }
+
+  return version
+}
+
+function resolvePeerContext(
+  lockResolution: PnpmLockDependencyResolution | undefined,
+): string | undefined {
+  const peerSuffix = lockResolution?.peerSuffix?.trim()
+
+  return peerSuffix === undefined || peerSuffix.length === 0
+    ? undefined
+    : peerSuffix
 }
 
 function diffPackageNode(
@@ -622,6 +679,18 @@ function diffDependency(
     kind: 'external',
     name: dependency.name,
     change,
+    specifierChanged: didExternalSpecifierChange(
+      beforeDependency,
+      afterDependency,
+    ),
+    resolvedVersionChanged: didExternalResolvedVersionChange(
+      beforeDependency,
+      afterDependency,
+    ),
+    peerContextChanged: didExternalPeerContextChange(
+      beforeDependency,
+      afterDependency,
+    ),
     ...(beforeDependency === undefined
       ? {}
       : { before: toDiffState(beforeDependency) }),
@@ -629,6 +698,39 @@ function diffDependency(
       ? {}
       : { after: toDiffState(afterDependency) }),
   }
+}
+
+function didExternalSpecifierChange(
+  beforeDependency: ComparablePackageDependency | undefined,
+  afterDependency: ComparablePackageDependency | undefined,
+): boolean {
+  return (
+    beforeDependency?.kind === 'external' &&
+    afterDependency?.kind === 'external' &&
+    beforeDependency.specifier !== afterDependency.specifier
+  )
+}
+
+function didExternalResolvedVersionChange(
+  beforeDependency: ComparablePackageDependency | undefined,
+  afterDependency: ComparablePackageDependency | undefined,
+): boolean {
+  return (
+    beforeDependency?.kind === 'external' &&
+    afterDependency?.kind === 'external' &&
+    beforeDependency.resolvedVersion !== afterDependency.resolvedVersion
+  )
+}
+
+function didExternalPeerContextChange(
+  beforeDependency: ComparablePackageDependency | undefined,
+  afterDependency: ComparablePackageDependency | undefined,
+): boolean {
+  return (
+    beforeDependency?.kind === 'external' &&
+    afterDependency?.kind === 'external' &&
+    beforeDependency.peerContext !== afterDependency.peerContext
+  )
 }
 
 function resolveDependencyChange(
@@ -655,7 +757,9 @@ function resolveDependencyChange(
     beforeDependency.kind === 'external' &&
     afterDependency.kind === 'external'
   ) {
-    return beforeDependency.specifier === afterDependency.specifier
+    return beforeDependency.specifier === afterDependency.specifier &&
+      beforeDependency.resolvedVersion === afterDependency.resolvedVersion &&
+      beforeDependency.peerContext === afterDependency.peerContext
       ? 'unchanged'
       : 'changed'
   }
@@ -680,6 +784,12 @@ function toDiffState(
     return {
       target: `${dependency.name}@${dependency.specifier}`,
       specifier: dependency.specifier,
+      ...(dependency.resolvedVersion === undefined
+        ? {}
+        : { resolvedVersion: dependency.resolvedVersion }),
+      ...(dependency.peerContext === undefined
+        ? {}
+        : { peerContext: dependency.peerContext }),
     }
   }
 

--- a/src/analyzers/deps/pnpm-lock.ts
+++ b/src/analyzers/deps/pnpm-lock.ts
@@ -1,0 +1,199 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+export interface PnpmLockDependencyResolution {
+  readonly specifier?: string
+  readonly version?: string
+  readonly peerSuffix?: string
+}
+
+export type PnpmLockImporterResolutions = ReadonlyMap<
+  string,
+  ReadonlyMap<string, PnpmLockDependencyResolution>
+>
+
+const PNPM_LOCKFILE = 'pnpm-lock.yaml'
+const DEPENDENCY_SECTIONS = new Set(['dependencies', 'optionalDependencies'])
+
+export function loadPnpmLockImporterResolutions(
+  repositoryRoot: string,
+): PnpmLockImporterResolutions | undefined {
+  const lockfilePath = path.join(repositoryRoot, PNPM_LOCKFILE)
+
+  if (!fs.existsSync(lockfilePath)) {
+    return undefined
+  }
+
+  return parsePnpmLockImporterResolutions(fs.readFileSync(lockfilePath, 'utf8'))
+}
+
+function parsePnpmLockImporterResolutions(
+  source: string,
+): PnpmLockImporterResolutions {
+  const importers = new Map<string, Map<string, PnpmLockDependencyResolution>>()
+  const lines = source.split(/\r?\n/u)
+  let inImporters = false
+  let currentImporter: string | undefined
+  let currentSection: string | undefined
+  let currentDependencyName: string | undefined
+
+  lines.forEach((line) => {
+    const trimmedLine = line.trim()
+    if (trimmedLine.length === 0 || trimmedLine.startsWith('#')) {
+      return
+    }
+
+    const indentation = line.length - line.trimStart().length
+
+    if (indentation === 0) {
+      if (trimmedLine === 'importers:') {
+        inImporters = true
+        currentImporter = undefined
+        currentSection = undefined
+        currentDependencyName = undefined
+        return
+      }
+
+      inImporters = false
+      return
+    }
+
+    if (!inImporters) {
+      return
+    }
+
+    if (indentation === 2 && trimmedLine.endsWith(':')) {
+      currentImporter = parseYamlScalar(trimmedLine.slice(0, -1))
+      currentSection = undefined
+      currentDependencyName = undefined
+
+      if (!importers.has(currentImporter)) {
+        importers.set(currentImporter, new Map())
+      }
+      return
+    }
+
+    if (currentImporter === undefined) {
+      return
+    }
+
+    if (indentation === 4 && trimmedLine.endsWith(':')) {
+      const sectionName = parseYamlScalar(trimmedLine.slice(0, -1))
+      currentSection = DEPENDENCY_SECTIONS.has(sectionName)
+        ? sectionName
+        : undefined
+      currentDependencyName = undefined
+      return
+    }
+
+    if (currentSection === undefined) {
+      return
+    }
+
+    if (indentation === 6) {
+      if (trimmedLine.endsWith(':')) {
+        currentDependencyName = parseYamlScalar(trimmedLine.slice(0, -1))
+        upsertDependency(importers, currentImporter, currentDependencyName, {})
+        return
+      }
+
+      const pair = splitYamlKeyValue(trimmedLine)
+      if (pair === undefined) {
+        return
+      }
+
+      currentDependencyName = undefined
+      upsertDependency(importers, currentImporter, parseYamlScalar(pair.key), {
+        ...parsePnpmVersion(parseYamlScalar(pair.value)),
+      })
+      return
+    }
+
+    if (indentation === 8 && currentDependencyName !== undefined) {
+      const pair = splitYamlKeyValue(trimmedLine)
+      if (pair === undefined) {
+        return
+      }
+
+      if (pair.key === 'specifier') {
+        upsertDependency(importers, currentImporter, currentDependencyName, {
+          specifier: parseYamlScalar(pair.value),
+        })
+        return
+      }
+
+      if (pair.key === 'version') {
+        upsertDependency(importers, currentImporter, currentDependencyName, {
+          ...parsePnpmVersion(parseYamlScalar(pair.value)),
+        })
+      }
+    }
+  })
+
+  return importers
+}
+
+function upsertDependency(
+  importers: Map<string, Map<string, PnpmLockDependencyResolution>>,
+  importerPath: string,
+  dependencyName: string,
+  nextValue: PnpmLockDependencyResolution,
+): void {
+  const importer = importers.get(importerPath)
+  if (importer === undefined) {
+    return
+  }
+
+  importer.set(dependencyName, {
+    ...importer.get(dependencyName),
+    ...nextValue,
+  })
+}
+
+function splitYamlKeyValue(
+  line: string,
+): { readonly key: string; readonly value: string } | undefined {
+  const separatorIndex = line.indexOf(':')
+
+  if (separatorIndex <= 0) {
+    return undefined
+  }
+
+  return {
+    key: line.slice(0, separatorIndex).trim(),
+    value: line.slice(separatorIndex + 1).trim(),
+  }
+}
+
+function parseYamlScalar(value: string): string {
+  if (value.length >= 2) {
+    const firstCharacter = value[0]
+    const lastCharacter = value[value.length - 1]
+
+    if (
+      (firstCharacter === '"' && lastCharacter === '"') ||
+      (firstCharacter === "'" && lastCharacter === "'")
+    ) {
+      return value.slice(1, -1)
+    }
+  }
+
+  return value
+}
+
+function parsePnpmVersion(
+  value: string,
+): Pick<PnpmLockDependencyResolution, 'version' | 'peerSuffix'> {
+  const firstParenthesisIndex = value.indexOf('(')
+
+  if (firstParenthesisIndex < 0) {
+    return {
+      version: value,
+    }
+  }
+
+  return {
+    version: value.slice(0, firstParenthesisIndex),
+    peerSuffix: value.slice(firstParenthesisIndex),
+  }
+}

--- a/src/output/ascii/deps.ts
+++ b/src/output/ascii/deps.ts
@@ -221,6 +221,9 @@ function formatDiffDependencyLabel(
 function formatExternalDiffLabel(
   dependency: Extract<PackageDependencyDiffDependency, { kind: 'external' }>,
 ): string {
+  const beforeResolution = dependency.before?.resolvedVersion
+  const afterResolution = dependency.after?.resolvedVersion
+
   if (dependency.change !== 'changed') {
     return (
       dependency.after?.target ?? dependency.before?.target ?? dependency.name
@@ -229,6 +232,21 @@ function formatExternalDiffLabel(
 
   const previousSpecifier = dependency.before?.specifier ?? 'none'
   const nextSpecifier = dependency.after?.specifier ?? 'none'
+
+  if (dependency.resolvedVersionChanged) {
+    const resolutionLabel = formatVersionChange(
+      beforeResolution,
+      afterResolution,
+    )
+
+    return previousSpecifier === nextSpecifier
+      ? `${dependency.name}@${nextSpecifier} (${resolutionLabel})`
+      : `${dependency.name}@${previousSpecifier} -> ${nextSpecifier} (${resolutionLabel})`
+  }
+
+  if (previousSpecifier === nextSpecifier) {
+    return `${dependency.name}@${nextSpecifier}`
+  }
 
   return `${dependency.name}@${previousSpecifier} -> ${nextSpecifier}`
 }
@@ -287,6 +305,13 @@ function formatWorkspaceState(
   }
 
   return `${target} (${state.specifier})`
+}
+
+function formatVersionChange(
+  beforeResolvedVersion: string | undefined,
+  afterResolvedVersion: string | undefined,
+): string {
+  return `${beforeResolvedVersion ?? 'none'} -> ${afterResolvedVersion ?? 'none'}`
 }
 
 function toMarker(change: PackageDependencyChangeKind): '+' | '-' | '~' {

--- a/src/output/json/deps.ts
+++ b/src/output/json/deps.ts
@@ -108,6 +108,13 @@ function serializePackageDiffDependency(
     kind: dependency.kind,
     name: dependency.name,
     change: dependency.change,
+    ...(dependency.kind === 'external'
+      ? {
+          specifierChanged: dependency.specifierChanged,
+          resolvedVersionChanged: dependency.resolvedVersionChanged,
+          peerContextChanged: dependency.peerContextChanged,
+        }
+      : {}),
     ...(dependency.before === undefined
       ? {}
       : {
@@ -115,6 +122,12 @@ function serializePackageDiffDependency(
           ...(dependency.before.specifier === undefined
             ? {}
             : { beforeSpecifier: dependency.before.specifier }),
+          ...(dependency.before.resolvedVersion === undefined
+            ? {}
+            : { beforeResolvedVersion: dependency.before.resolvedVersion }),
+          ...(dependency.before.peerContext === undefined
+            ? {}
+            : { beforePeerContext: dependency.before.peerContext }),
         }),
     ...(dependency.after === undefined
       ? {}
@@ -123,6 +136,12 @@ function serializePackageDiffDependency(
           ...(dependency.after.specifier === undefined
             ? {}
             : { afterSpecifier: dependency.after.specifier }),
+          ...(dependency.after.resolvedVersion === undefined
+            ? {}
+            : { afterResolvedVersion: dependency.after.resolvedVersion }),
+          ...(dependency.after.peerContext === undefined
+            ? {}
+            : { afterPeerContext: dependency.after.peerContext }),
         }),
     ...(dependency.before === undefined ? {} : { before: dependency.before }),
     ...(dependency.after === undefined ? {} : { after: dependency.after }),

--- a/src/types/package-dependency-diff-dependency.ts
+++ b/src/types/package-dependency-diff-dependency.ts
@@ -4,6 +4,8 @@ import type { PackageDependencyDiffNode } from './package-dependency-diff-node.j
 export interface PackageDependencyDiffState {
   readonly target: string
   readonly specifier?: string
+  readonly resolvedVersion?: string
+  readonly peerContext?: string
 }
 
 interface BasePackageDependencyDiffDependency {
@@ -16,6 +18,9 @@ interface BasePackageDependencyDiffDependency {
 export interface ExternalPackageDependencyDiff
   extends BasePackageDependencyDiffDependency {
   readonly kind: 'external'
+  readonly specifierChanged: boolean
+  readonly resolvedVersionChanged: boolean
+  readonly peerContextChanged: boolean
 }
 
 export interface WorkspacePackageDependencyDiff

--- a/test/deps-analyzer.test.ts
+++ b/test/deps-analyzer.test.ts
@@ -348,6 +348,174 @@ describe('analyzePackageDependencies', () => {
     })
   })
 
+  it('prefers pnpm lockfile resolutions for lockfile-only dependency diffs', () => {
+    const repositoryRoot = createGitRepository([
+      {
+        message: 'initial',
+        files: {
+          'package.json': JSON.stringify(
+            {
+              name: 'diff-lockfile-package',
+              dependencies: {
+                react: '^19.0.0',
+              },
+            },
+            null,
+            2,
+          ),
+          'pnpm-lock.yaml': [
+            "lockfileVersion: '9.0'",
+            '',
+            'importers:',
+            '  .:',
+            '    dependencies:',
+            '      react:',
+            '        specifier: ^19.0.0',
+            '        version: 19.1.0(next@15.0.0)(react-dom@18.2.0(react@18.2.0))',
+            '',
+          ].join('\n'),
+        },
+      },
+      {
+        message: 'update lockfile only',
+        files: {
+          'package.json': JSON.stringify(
+            {
+              name: 'diff-lockfile-package',
+              dependencies: {
+                react: '^19.0.0',
+              },
+            },
+            null,
+            2,
+          ),
+          'pnpm-lock.yaml': [
+            "lockfileVersion: '9.0'",
+            '',
+            'importers:',
+            '  .:',
+            '    dependencies:',
+            '      react:',
+            '        specifier: ^19.0.0',
+            '        version: 19.1.1(next@16.0.0)(react-dom@18.2.0(react@18.2.0))',
+            '',
+          ].join('\n'),
+        },
+      },
+    ])
+
+    const graph = analyzePackageDependencyDiff(repositoryRoot, 'HEAD~1')
+    const output = printPackageDependencyDiffTree(graph, {
+      color: false,
+    })
+    const jsonTree = diffGraphToSerializablePackageTree(graph)
+
+    expect(output).toBe(
+      ['~ diff-lockfile-package', '└─ ~ react@^19.0.0 (19.1.0 -> 19.1.1)'].join(
+        '\n',
+      ),
+    )
+    expect(jsonTree).toMatchObject({
+      kind: 'root',
+      label: 'diff-lockfile-package',
+      packageName: 'diff-lockfile-package',
+      path: '.',
+      change: 'changed',
+      dependencies: [
+        {
+          kind: 'external',
+          name: 'react',
+          change: 'changed',
+          specifierChanged: false,
+          resolvedVersionChanged: true,
+          peerContextChanged: true,
+          before: {
+            target: 'react@^19.0.0',
+            specifier: '^19.0.0',
+            resolvedVersion: '19.1.0',
+            peerContext: '(next@15.0.0)(react-dom@18.2.0(react@18.2.0))',
+          },
+          after: {
+            target: 'react@^19.0.0',
+            specifier: '^19.0.0',
+            resolvedVersion: '19.1.1',
+            peerContext: '(next@16.0.0)(react-dom@18.2.0(react@18.2.0))',
+          },
+          beforeResolvedVersion: '19.1.0',
+          afterResolvedVersion: '19.1.1',
+          beforePeerContext: '(next@15.0.0)(react-dom@18.2.0(react@18.2.0))',
+          afterPeerContext: '(next@16.0.0)(react-dom@18.2.0(react@18.2.0))',
+        },
+      ],
+    })
+  })
+
+  it('does not repeat identical specifiers when only peer context changes', () => {
+    const repositoryRoot = createGitRepository([
+      {
+        message: 'initial',
+        files: {
+          'package.json': JSON.stringify(
+            {
+              name: 'diff-peer-context-package',
+              dependencies: {
+                'next-seo': '^6.0.0',
+              },
+            },
+            null,
+            2,
+          ),
+          'pnpm-lock.yaml': [
+            "lockfileVersion: '9.0'",
+            '',
+            'importers:',
+            '  .:',
+            '    dependencies:',
+            '      next-seo:',
+            '        specifier: ^6.0.0',
+            '        version: 6.0.0(next@15.0.0)(react@18.2.0)',
+            '',
+          ].join('\n'),
+        },
+      },
+      {
+        message: 'update peer context only',
+        files: {
+          'package.json': JSON.stringify(
+            {
+              name: 'diff-peer-context-package',
+              dependencies: {
+                'next-seo': '^6.0.0',
+              },
+            },
+            null,
+            2,
+          ),
+          'pnpm-lock.yaml': [
+            "lockfileVersion: '9.0'",
+            '',
+            'importers:',
+            '  .:',
+            '    dependencies:',
+            '      next-seo:',
+            '        specifier: ^6.0.0',
+            '        version: 6.0.0(next@16.0.0)(react@18.2.0)',
+            '',
+          ].join('\n'),
+        },
+      },
+    ])
+
+    const graph = analyzePackageDependencyDiff(repositoryRoot, 'HEAD~1')
+    const output = printPackageDependencyDiffTree(graph, {
+      color: false,
+    })
+
+    expect(output).toBe(
+      ['~ diff-peer-context-package', '└─ ~ next-seo@^6.0.0'].join('\n'),
+    )
+  })
+
   it('can colorize dependency diff output', () => {
     const repositoryRoot = createGitRepository([
       {


### PR DESCRIPTION
## Summary
- prefer pnpm lockfile data when computing `deps --diff`
- surface resolved version and peer context changes in JSON output for deployment tooling
- keep ASCII diff output concise for lockfile-only and peer-context-only changes

## Testing
- `pnpm typecheck`
- `pnpm exec vitest run test/deps-analyzer.test.ts`
- `pnpm lint`

Closes #49
