### PR TITLE
fix: avoid re-expanding shared import subgraphs

### DIFF
--- a/src/output/ascii/import.ts
+++ b/src/output/ascii/import.ts
@@ -14,6 +14,7 @@ export function printDependencyTree(
   const omitUnused = options.omitUnused ?? false
   const rootLines = [toDisplayPath(graph.entryId, cwd)]
   const visited = new Set<string>([graph.entryId])
+  const expanded = new Set<string>([graph.entryId])
   const entryNode = graph.nodes.get(graph.entryId)
 
   if (entryNode === undefined) {
@@ -32,6 +33,7 @@ export function printDependencyTree(
         dependency,
         graph,
         visited,
+        expanded,
         '',
         index === rootDependencies.length - 1,
         includeExternals,
@@ -49,6 +51,7 @@ function renderDependency(
   dependency: DependencyEdge,
   graph: DependencyGraph,
   visited: ReadonlySet<string>,
+  expanded: Set<string>,
   prefix: string,
   isLast: boolean,
   includeExternals: boolean,
@@ -72,9 +75,14 @@ function renderDependency(
     return [`${branch}${label}`]
   }
 
+  if (expanded.has(dependency.target)) {
+    return [`${branch}${label} (shared)`]
+  }
+
   const nextPrefix = `${prefix}${isLast ? '   ' : '│  '}`
   const nextVisited = new Set(visited)
   nextVisited.add(dependency.target)
+  expanded.add(dependency.target)
 
   const childLines = [`${branch}${label}`]
   const childDependencies = filterDependencies(
@@ -89,6 +97,7 @@ function renderDependency(
         childDependency,
         graph,
         nextVisited,
+        expanded,
         nextPrefix,
         index === childDependencies.length - 1,
         includeExternals,

--- a/src/output/json/import.ts
+++ b/src/output/json/import.ts
@@ -8,11 +8,11 @@ export function graphToSerializableTree(
     readonly omitUnused?: boolean
   } = {},
 ): object {
-  const visited = new Set<string>()
   return serializeNode(
     graph.entryId,
     graph,
-    visited,
+    new Set<string>(),
+    new Set<string>(),
     options.omitUnused ?? false,
   )
 }
@@ -20,7 +20,8 @@ export function graphToSerializableTree(
 function serializeNode(
   filePath: string,
   graph: DependencyGraph,
-  visited: Set<string>,
+  visited: ReadonlySet<string>,
+  expanded: Set<string>,
   omitUnused: boolean,
 ): object {
   const node = graph.nodes.get(filePath)
@@ -42,7 +43,17 @@ function serializeNode(
     }
   }
 
-  visited.add(filePath)
+  if (expanded.has(filePath)) {
+    return {
+      path: displayPath,
+      kind: 'shared',
+      dependencies: [],
+    }
+  }
+
+  const nextVisited = new Set(visited)
+  nextVisited.add(filePath)
+  expanded.add(filePath)
 
   const dependencies = node.dependencies
     .filter((dependency) => !omitUnused || !dependency.unused)
@@ -71,7 +82,8 @@ function serializeNode(
         node: serializeNode(
           dependency.target,
           graph,
-          new Set(visited),
+          nextVisited,
+          expanded,
           omitUnused,
         ),
       }

--- a/test/analyzer.test.ts
+++ b/test/analyzer.test.ts
@@ -8,6 +8,8 @@ import {
   graphToSerializableTree,
   printDependencyTree,
 } from '../src/index.js'
+import type { DependencyEdge } from '../src/types/dependency-edge.js'
+import type { DependencyGraph } from '../src/types/dependency-graph.js'
 
 const currentDirectory = path.dirname(fileURLToPath(import.meta.url))
 const fixtureDirectory = path.join(currentDirectory, 'fixtures', 'basic')
@@ -134,6 +136,74 @@ describe('analyzeDependencies', () => {
     expect(output).toContain(
       'src/unused-helper.ts \u001B[38;5;214m(unused)\u001B[0m',
     )
+  })
+
+  it('renders shared source subgraphs only once in ascii output', () => {
+    const graph = createSharedSubgraphFixture()
+
+    const output = printDependencyTree(graph, {
+      color: false,
+    })
+
+    expect(output).toContain('src/shared.ts')
+    expect(output).toContain('src/shared.ts (shared)')
+    expect(output).toContain('src/shared-leaf.ts')
+    expect(output.match(/src\/shared-leaf\.ts/g)).toHaveLength(1)
+  })
+
+  it('serializes repeated source subgraphs as shared references in json output', () => {
+    const graph = createSharedSubgraphFixture()
+
+    const jsonTree = graphToSerializableTree(graph)
+
+    expect(jsonTree).toMatchObject({
+      kind: 'entry',
+      path: 'src/entry.ts',
+      dependencies: [
+        {
+          target: 'src/left.ts',
+          node: {
+            kind: 'source',
+            path: 'src/left.ts',
+            dependencies: [
+              {
+                target: 'src/shared.ts',
+                node: {
+                  kind: 'source',
+                  path: 'src/shared.ts',
+                  dependencies: [
+                    {
+                      target: 'src/shared-leaf.ts',
+                      node: {
+                        kind: 'source',
+                        path: 'src/shared-leaf.ts',
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        {
+          target: 'src/right.ts',
+          node: {
+            kind: 'source',
+            path: 'src/right.ts',
+            dependencies: [
+              {
+                target: 'src/shared.ts',
+                node: {
+                  kind: 'shared',
+                  path: 'src/shared.ts',
+                  dependencies: [],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    })
   })
 
   it('expands sibling workspace packages and their own tsconfig aliases by default', () => {
@@ -269,6 +339,71 @@ describe('analyzeDependencies', () => {
     expect(output).toContain('broken-package [external]')
   })
 })
+
+function createSharedSubgraphFixture(): DependencyGraph {
+  const cwd = '/repo'
+  const entryId = path.join(cwd, 'src', 'entry.ts')
+  const leftId = path.join(cwd, 'src', 'left.ts')
+  const rightId = path.join(cwd, 'src', 'right.ts')
+  const sharedId = path.join(cwd, 'src', 'shared.ts')
+  const leafId = path.join(cwd, 'src', 'shared-leaf.ts')
+
+  return {
+    cwd,
+    entryId,
+    nodes: new Map([
+      [
+        entryId,
+        {
+          id: entryId,
+          dependencies: [
+            createSourceEdge('./left', leftId),
+            createSourceEdge('./right', rightId),
+          ],
+        },
+      ],
+      [
+        leftId,
+        {
+          id: leftId,
+          dependencies: [createSourceEdge('./shared', sharedId)],
+        },
+      ],
+      [
+        rightId,
+        {
+          id: rightId,
+          dependencies: [createSourceEdge('./shared', sharedId)],
+        },
+      ],
+      [
+        sharedId,
+        {
+          id: sharedId,
+          dependencies: [createSourceEdge('./shared-leaf', leafId)],
+        },
+      ],
+      [
+        leafId,
+        {
+          id: leafId,
+          dependencies: [],
+        },
+      ],
+    ]),
+  }
+}
+
+function createSourceEdge(specifier: string, target: string): DependencyEdge {
+  return {
+    specifier,
+    referenceKind: 'import',
+    isTypeOnly: false,
+    unused: false,
+    kind: 'source',
+    target,
+  }
+}
 
 function findDependencyByPath(
   tree: object,


### PR DESCRIPTION
## Summary
- stop re-expanding shared source subgraphs in ASCII import output and mark repeated nodes as `(shared)`
- serialize repeated source subgraphs in JSON as `kind: "shared"` references while preserving per-path circular detection
- add regression tests covering repeated shared DAG branches

## Testing
- pnpm test -- --runInBand
- pnpm lint
- pnpm typecheck
- pnpm build
- verified the reported large monorepo Next.js page reproduction in both ASCII and JSON modes

## Issue
- closes #55
