### PR TITLE
perf: share dependency graph across react entries

### DIFF
--- a/src/analyzers/import/graph.ts
+++ b/src/analyzers/import/graph.ts
@@ -10,16 +10,20 @@ import { collectModuleReferences } from './references.js'
 import { resolveDependency } from './resolver.js'
 
 export function buildDependencyGraph(
-  entryPath: string,
+  entryConfigs: readonly EntryConfig[],
   options: BuildDependencyGraphOptions,
 ): Map<string, SourceModuleNode> {
-  return new DependencyGraphBuilder(entryPath, options).build()
+  return new DependencyGraphBuilder(entryConfigs, options).build()
+}
+
+export interface EntryConfig {
+  readonly entryPath: string
+  readonly compilerOptions: ts.CompilerOptions
+  readonly configPath?: string
 }
 
 export interface BuildDependencyGraphOptions {
   readonly cwd: string
-  readonly entryConfigPath?: string
-  readonly entryCompilerOptions: ts.CompilerOptions
   readonly expandWorkspaces: boolean
   readonly projectOnly: boolean
 }
@@ -35,25 +39,27 @@ class DependencyGraphBuilder {
   private readonly resolverCache = new Map<string, ResolverFactory>()
 
   constructor(
-    private readonly entryPath: string,
+    private readonly entryConfigs: readonly EntryConfig[],
     private readonly options: BuildDependencyGraphOptions,
   ) {
-    const entryConfig: import('./resolver.js').ResolverConfigContext = {
-      compilerOptions: options.entryCompilerOptions,
-      ...(options.entryConfigPath === undefined
-        ? {}
-        : { path: options.entryConfigPath }),
-    }
-
-    this.configCache.set(path.dirname(this.entryPath), entryConfig)
+    entryConfigs.forEach((entryConfig) => {
+      this.configCache.set(path.dirname(entryConfig.entryPath), {
+        compilerOptions: entryConfig.compilerOptions,
+        ...(entryConfig.configPath === undefined
+          ? {}
+          : { path: entryConfig.configPath }),
+      })
+    })
   }
 
   build(): Map<string, SourceModuleNode> {
-    this.visitFile(this.entryPath)
+    this.entryConfigs.forEach((entryConfig) => {
+      this.visitFile(entryConfig.entryPath, entryConfig.configPath)
+    })
     return this.nodes
   }
 
-  private visitFile(filePath: string): void {
+  private visitFile(filePath: string, entryConfigPath?: string): void {
     const normalizedPath = normalizeFilePath(filePath)
     if (this.nodes.has(normalizedPath)) {
       return
@@ -73,9 +79,7 @@ class DependencyGraphBuilder {
         projectOnly: this.options.projectOnly,
         getConfigForFile: (targetPath) => this.getConfigForFile(targetPath),
         getResolverForFile: (targetPath) => this.getResolverForFile(targetPath),
-        ...(this.options.entryConfigPath === undefined
-          ? {}
-          : { entryConfigPath: this.options.entryConfigPath }),
+        ...(entryConfigPath === undefined ? {} : { entryConfigPath }),
       }),
     )
 
@@ -86,7 +90,7 @@ class DependencyGraphBuilder {
 
     for (const dependency of dependencies) {
       if (dependency.kind === 'source') {
-        this.visitFile(dependency.target)
+        this.visitFile(dependency.target, entryConfigPath)
       }
     }
   }

--- a/src/analyzers/import/index.ts
+++ b/src/analyzers/import/index.ts
@@ -2,6 +2,8 @@ import path from 'node:path'
 
 import type { AnalyzeOptions } from '../../types/analyze-options.js'
 import type { DependencyGraph } from '../../types/dependency-graph.js'
+import type ts from 'typescript'
+
 import { loadCompilerOptions } from '../../typescript/config.js'
 import { BaseAnalyzer } from '../base.js'
 import { resolveExistingPath } from './entry.js'
@@ -11,37 +13,110 @@ export function analyzeDependencies(
   entryFile: string,
   options: AnalyzeOptions = {},
 ): DependencyGraph {
-  return new ImportAnalyzer(entryFile, options).analyze()
+  const graph = analyzeDependenciesForEntries([entryFile], options)
+
+  return {
+    cwd: graph.cwd,
+    entryId: graph.entryId,
+    nodes: graph.nodes,
+    ...(graph.configPath === undefined ? {} : { configPath: graph.configPath }),
+  }
 }
 
-class ImportAnalyzer extends BaseAnalyzer<DependencyGraph> {
-  private readonly cwd: string
-  private readonly entryPath: string
+export interface MultiEntryDependencyGraph extends DependencyGraph {
+  readonly entryIds: readonly string[]
+}
 
-  constructor(entryFile: string, options: AnalyzeOptions) {
-    super(entryFile, options)
+export function analyzeDependenciesForEntries(
+  entryFiles: readonly string[],
+  options: AnalyzeOptions = {},
+): MultiEntryDependencyGraph {
+  return new MultiEntryImportAnalyzer(entryFiles, options).analyze()
+}
+
+class MultiEntryImportAnalyzer extends BaseAnalyzer<MultiEntryDependencyGraph> {
+  private readonly cwd: string
+  private readonly entryPaths: readonly string[]
+
+  constructor(entryFiles: readonly string[], options: AnalyzeOptions) {
+    const [firstEntryFile] = entryFiles
+    if (firstEntryFile === undefined) {
+      throw new Error('At least one entry file is required.')
+    }
+
+    super(firstEntryFile, options)
     this.cwd = path.resolve(options.cwd ?? process.cwd())
-    this.entryPath = resolveExistingPath(this.cwd, entryFile)
+    this.entryPaths = [...new Set(entryFiles)].map((entryFile) =>
+      resolveExistingPath(this.cwd, entryFile),
+    )
   }
 
-  protected doAnalyze(): DependencyGraph {
-    const { compilerOptions, path: configPath } = loadCompilerOptions(
-      path.dirname(this.entryPath),
-      this.options.configPath,
-    )
-    const nodes = buildDependencyGraph(this.entryPath, {
+  protected doAnalyze(): MultiEntryDependencyGraph {
+    const entryConfigs = this.resolveEntryConfigs()
+    const nodes = buildDependencyGraph(entryConfigs, {
       cwd: this.cwd,
-      entryCompilerOptions: compilerOptions,
       expandWorkspaces: this.options.expandWorkspaces ?? true,
       projectOnly: this.options.projectOnly ?? false,
-      ...(configPath === undefined ? {} : { entryConfigPath: configPath }),
     })
+    const uniqueConfigPaths = [...new Set(entryConfigs.map((entry) => entry.configPath))]
+    const configPath =
+      uniqueConfigPaths.length === 1 ? uniqueConfigPaths[0] : undefined
+    const [firstEntryPath] = this.entryPaths
+
+    if (firstEntryPath === undefined) {
+      throw new Error('At least one entry file is required.')
+    }
 
     return {
       cwd: this.cwd,
-      entryId: this.entryPath,
+      entryId: firstEntryPath,
+      entryIds: this.entryPaths,
       nodes,
       ...(configPath === undefined ? {} : { configPath }),
     }
   }
+
+  private resolveEntryConfigs(): EntryConfig[] {
+    const configCache = new Map<string, LoadedEntryConfig>()
+
+    return this.entryPaths.map((entryPath) => {
+      const directory = path.dirname(entryPath)
+      const cached = configCache.get(directory)
+      if (cached !== undefined) {
+        return {
+          entryPath,
+          compilerOptions: cached.compilerOptions,
+          ...(cached.configPath === undefined
+            ? {}
+            : { configPath: cached.configPath }),
+        }
+      }
+
+      const loaded = loadCompilerOptions(directory, this.options.configPath)
+      const resolved: LoadedEntryConfig = {
+        compilerOptions: loaded.compilerOptions,
+        ...(loaded.path === undefined ? {} : { configPath: loaded.path }),
+      }
+      configCache.set(directory, resolved)
+
+      return {
+        entryPath,
+        compilerOptions: resolved.compilerOptions,
+        ...(resolved.configPath === undefined
+          ? {}
+          : { configPath: resolved.configPath }),
+      }
+    })
+  }
+}
+
+interface EntryConfig {
+  readonly entryPath: string
+  readonly compilerOptions: ts.CompilerOptions
+  readonly configPath?: string
+}
+
+interface LoadedEntryConfig {
+  readonly compilerOptions: ts.CompilerOptions
+  readonly configPath?: string
 }

--- a/src/analyzers/import/index.ts
+++ b/src/analyzers/import/index.ts
@@ -1,8 +1,8 @@
 import path from 'node:path'
 
+import type ts from 'typescript'
 import type { AnalyzeOptions } from '../../types/analyze-options.js'
 import type { DependencyGraph } from '../../types/dependency-graph.js'
-import type ts from 'typescript'
 
 import { loadCompilerOptions } from '../../typescript/config.js'
 import { BaseAnalyzer } from '../base.js'
@@ -58,7 +58,9 @@ class MultiEntryImportAnalyzer extends BaseAnalyzer<MultiEntryDependencyGraph> {
       expandWorkspaces: this.options.expandWorkspaces ?? true,
       projectOnly: this.options.projectOnly ?? false,
     })
-    const uniqueConfigPaths = [...new Set(entryConfigs.map((entry) => entry.configPath))]
+    const uniqueConfigPaths = [
+      ...new Set(entryConfigs.map((entry) => entry.configPath)),
+    ]
     const configPath =
       uniqueConfigPaths.length === 1 ? uniqueConfigPaths[0] : undefined
     const [firstEntryPath] = this.entryPaths

--- a/src/analyzers/react/index.spec.ts
+++ b/src/analyzers/react/index.spec.ts
@@ -1,9 +1,56 @@
-import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
 
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { analyzeDependenciesForEntries } from '../import/index.js'
+import { analyzeReactFile } from './file.js'
 import { analyzeReactUsage } from './index.js'
+
+vi.mock('../import/index.js', () => ({
+  analyzeDependenciesForEntries: vi.fn(),
+}))
+
+vi.mock('./file.js', () => ({
+  analyzeReactFile: vi.fn(),
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.restoreAllMocks()
+})
 
 describe('analyzeReactUsage', () => {
   it('exports a callable react analyzer', () => {
     expect(analyzeReactUsage).toBeTypeOf('function')
+  })
+
+  it('builds dependencies once for multi-entry analysis', () => {
+    vi.mocked(analyzeDependenciesForEntries).mockReturnValue({
+      cwd: '/repo',
+      entryId: '/repo/src/a.tsx',
+      entryIds: ['/repo/src/a.tsx', '/repo/src/b.tsx'],
+      nodes: new Map(),
+    })
+    vi.spyOn(fs, 'readFileSync').mockReturnValue('')
+    vi.mocked(analyzeReactFile).mockReturnValue({
+      filePath: '/repo/src/a.tsx',
+      importsByLocalName: new Map(),
+      exportsByName: new Map(),
+      reExportBindingsByName: new Map(),
+      exportAllBindings: [],
+      entryUsages: [],
+      allSymbolsById: new Map(),
+      allSymbolsByName: new Map(),
+      symbolsById: new Map(),
+      symbolsByName: new Map(),
+    })
+
+    analyzeReactUsage(['src/a.tsx', 'src/b.tsx'], { cwd: '/repo' })
+
+    expect(analyzeDependenciesForEntries).toHaveBeenCalledTimes(1)
+    expect(analyzeDependenciesForEntries).toHaveBeenCalledWith(
+      ['src/a.tsx', 'src/b.tsx'],
+      { cwd: '/repo' },
+    )
   })
 })

--- a/src/analyzers/react/index.ts
+++ b/src/analyzers/react/index.ts
@@ -3,15 +3,16 @@ import fs from 'node:fs'
 import { parseSync } from 'oxc-parser'
 
 import type { AnalyzeOptions } from '../../types/analyze-options.js'
-import type { DependencyGraph } from '../../types/dependency-graph.js'
 import type { ReactUsageEdge } from '../../types/react-usage-edge.js'
 import type { ReactUsageEntry } from '../../types/react-usage-entry.js'
 import type { ReactUsageGraph } from '../../types/react-usage-graph.js'
 import type { ReactUsageNode } from '../../types/react-usage-node.js'
-import type { SourceModuleNode } from '../../types/source-module-node.js'
 import { isSourceCodeFile } from '../../utils/is-source-code-file.js'
 import { BaseAnalyzer } from '../base.js'
-import { analyzeDependencies } from '../import/index.js'
+import {
+  analyzeDependenciesForEntries,
+  type MultiEntryDependencyGraph,
+} from '../import/index.js'
 import { analyzeReactFile } from './file.js'
 import {
   addBuiltinNodes,
@@ -43,11 +44,10 @@ class ReactAnalyzer extends BaseAnalyzer<ReactUsageGraph> {
   }
 
   protected doAnalyze(): ReactUsageGraph {
-    const dependencyGraphs = this.entryFiles.map((entryFile) =>
-      analyzeDependencies(entryFile, this.options),
+    const dependencyGraph = analyzeDependenciesForEntries(
+      this.entryFiles,
+      this.options,
     )
-    const dependencyGraph = mergeDependencyGraphs(dependencyGraphs)
-    const entryIds = dependencyGraphs.map((graph) => graph.entryId)
     const fileAnalyses = this.collectFileAnalyses(dependencyGraph)
     const nodes = this.createNodes(fileAnalyses)
     this.attachUsages(fileAnalyses, nodes)
@@ -56,14 +56,14 @@ class ReactAnalyzer extends BaseAnalyzer<ReactUsageGraph> {
     return {
       cwd: dependencyGraph.cwd,
       entryId: dependencyGraph.entryId,
-      entryIds,
+      entryIds: dependencyGraph.entryIds,
       nodes,
       entries,
     }
   }
 
   private collectFileAnalyses(
-    dependencyGraph: MergedDependencyGraph,
+    dependencyGraph: MultiEntryDependencyGraph,
   ): Map<string, import('./file.js').FileAnalysis> {
     const reachableFiles = new Set<string>([
       ...dependencyGraph.entryIds,
@@ -241,40 +241,4 @@ function normalizeEntryFiles(entryFile: string | readonly string[]): string[] {
   }
 
   return dedupedEntryFiles
-}
-
-function mergeDependencyGraphs(
-  graphs: readonly DependencyGraph[],
-): MergedDependencyGraph {
-  const firstGraph = graphs[0]
-  if (firstGraph === undefined) {
-    throw new Error('At least one dependency graph is required.')
-  }
-
-  const nodes = new Map<string, SourceModuleNode>()
-  for (const graph of graphs) {
-    for (const [nodeId, node] of graph.nodes) {
-      if (!nodes.has(nodeId)) {
-        nodes.set(nodeId, node)
-      }
-    }
-  }
-
-  const uniqueConfigPaths = [
-    ...new Set(graphs.map((graph) => graph.configPath)),
-  ]
-  const configPath =
-    uniqueConfigPaths.length === 1 ? uniqueConfigPaths[0] : undefined
-
-  return {
-    cwd: firstGraph.cwd,
-    entryId: firstGraph.entryId,
-    entryIds: graphs.map((graph) => graph.entryId),
-    nodes,
-    ...(configPath === undefined ? {} : { configPath }),
-  }
-}
-
-interface MergedDependencyGraph extends DependencyGraph {
-  readonly entryIds: readonly string[]
 }


### PR DESCRIPTION
## Summary
- build a shared dependency graph once for multi-entry React analysis
- update React analysis to consume the shared multi-entry graph instead of re-running import analysis per entry
- add a regression test that asserts multi-entry React analysis only builds dependencies once

## Testing
- `pnpm test:unit -- --runInBand`
- `pnpm typecheck`
- `pnpm build`
- `/usr/bin/time -lp node dist/cli.mjs react --nextjs --cwd /Users/sophia-dev/projects/cht-homepage/apps/cht-homepage >/dev/null`

## Benchmark
For `node dist/cli.mjs react --nextjs --cwd /Users/sophia-dev/projects/cht-homepage/apps/cht-homepage >/dev/null`:
- before: still running after 3m14s, RSS about 2.63 GB
- after: `real 16.28`, max RSS about 1.15 GB

Closes #75
