### PR TITLE
perf: cache line offsets for react usage locations

### DIFF
--- a/src/analyzers/react/entries.spec.ts
+++ b/src/analyzers/react/entries.spec.ts
@@ -11,4 +11,42 @@ describe('react entry helpers', () => {
       column: 1,
     })
   })
+
+  it('resolves later lines and columns without rescanning semantics regressions', () => {
+    const sourceText = ['const one = 1;', 'const two = 2;', 'return two;'].join(
+      '\n',
+    )
+
+    expect(
+      createReactUsageLocation(
+        'src/App.tsx',
+        sourceText,
+        sourceText.indexOf('two'),
+      ),
+    ).toEqual({
+      filePath: 'src/App.tsx',
+      line: 2,
+      column: 7,
+    })
+
+    expect(
+      createReactUsageLocation(
+        'src/App.tsx',
+        sourceText,
+        sourceText.indexOf('return'),
+      ),
+    ).toEqual({
+      filePath: 'src/App.tsx',
+      line: 3,
+      column: 1,
+    })
+  })
+
+  it('clamps offsets beyond the end of the source text', () => {
+    expect(createReactUsageLocation('src/App.tsx', 'abc', 99)).toEqual({
+      filePath: 'src/App.tsx',
+      line: 1,
+      column: 4,
+    })
+  })
 })

--- a/src/analyzers/react/entries.ts
+++ b/src/analyzers/react/entries.ts
@@ -18,6 +18,8 @@ export interface PendingReactUsageEntry {
   readonly location: ReactUsageLocation
 }
 
+const lineStartOffsetsCache = new Map<string, readonly number[]>()
+
 export function collectEntryUsages(
   program: Program,
   filePath: string,
@@ -204,20 +206,15 @@ function offsetToLineAndColumn(
   sourceText: string,
   offset: number,
 ): Pick<ReactUsageLocation, 'line' | 'column'> {
-  let line = 1
-  let column = 1
+  const lineStartOffsets = getLineStartOffsets(sourceText)
+  const boundedOffset = Math.max(0, Math.min(offset, sourceText.length))
+  const lineIndex = findLineIndex(lineStartOffsets, boundedOffset)
+  const lineStartOffset = lineStartOffsets[lineIndex] ?? 0
 
-  for (let index = 0; index < offset && index < sourceText.length; index += 1) {
-    if (sourceText[index] === '\n') {
-      line += 1
-      column = 1
-      continue
-    }
-
-    column += 1
+  return {
+    line: lineIndex + 1,
+    column: boundedOffset - lineStartOffset + 1,
   }
-
-  return { line, column }
 }
 
 function comparePendingReactUsageEntries(
@@ -231,4 +228,52 @@ function comparePendingReactUsageEntries(
     left.kind.localeCompare(right.kind) ||
     left.referenceName.localeCompare(right.referenceName)
   )
+}
+
+function getLineStartOffsets(sourceText: string): readonly number[] {
+  const cached = lineStartOffsetsCache.get(sourceText)
+  if (cached !== undefined) {
+    return cached
+  }
+
+  const lineStartOffsets = [0]
+  for (let index = 0; index < sourceText.length; index += 1) {
+    if (sourceText[index] === '\n') {
+      lineStartOffsets.push(index + 1)
+    }
+  }
+
+  lineStartOffsetsCache.set(sourceText, lineStartOffsets)
+  return lineStartOffsets
+}
+
+function findLineIndex(
+  lineStartOffsets: readonly number[],
+  offset: number,
+): number {
+  let lowerBound = 0
+  let upperBound = lineStartOffsets.length - 1
+
+  while (lowerBound <= upperBound) {
+    const middleIndex = Math.floor((lowerBound + upperBound) / 2)
+    const middleOffset = lineStartOffsets[middleIndex]
+    const nextOffset = lineStartOffsets[middleIndex + 1]
+
+    if (middleOffset === undefined) {
+      return 0
+    }
+
+    if (offset < middleOffset) {
+      upperBound = middleIndex - 1
+      continue
+    }
+
+    if (nextOffset === undefined || offset < nextOffset) {
+      return middleIndex
+    }
+
+    lowerBound = middleIndex + 1
+  }
+
+  return Math.max(0, lineStartOffsets.length - 1)
 }


### PR DESCRIPTION
## Summary
- cache line start offsets for `createReactUsageLocation()`
- replace repeated O(n) offset scans with binary search over cached line starts
- add unit coverage for later lines and end-of-file clamping

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit -- --runInBand`
- `pnpm build`
- `/usr/bin/time -lp node dist/cli.mjs react --nextjs --cwd /Users/sophia-dev/projects/cht-homepage/apps/cht-homepage >/dev/null`

## Benchmark
Microbenchmark with a 20k-line synthetic source and 5 x 5,023 lookups:
- before: `23955.84ms`
- after: `9.8ms`

Representative end-to-end benchmark:
- before: `16.28s`
- after: `16.50s`

Closes #72
