### PR TITLE
perf: skip unused import tracking for react analysis

### DIFF
--- a/src/analyzers/import/graph.ts
+++ b/src/analyzers/import/graph.ts
@@ -29,6 +29,7 @@ export interface BuildDependencyGraphOptions {
   readonly cwd: string
   readonly expandWorkspaces: boolean
   readonly projectOnly: boolean
+  readonly trackUnusedImports: boolean
 }
 
 class DependencyGraphBuilder {
@@ -75,7 +76,9 @@ class DependencyGraphBuilder {
 
     const config = this.getConfigForFile(normalizedPath)
     const program = this.getProgramForFile(normalizedPath, config)
-    const checker = this.getCheckerForFile(normalizedPath, config)
+    const checker = this.options.trackUnusedImports
+      ? this.getCheckerForFile(normalizedPath, config)
+      : undefined
     const sourceFile =
       program.getSourceFile(normalizedPath) ?? createSourceFile(normalizedPath)
 

--- a/src/analyzers/import/index.ts
+++ b/src/analyzers/import/index.ts
@@ -57,6 +57,7 @@ class MultiEntryImportAnalyzer extends BaseAnalyzer<MultiEntryDependencyGraph> {
       cwd: this.cwd,
       expandWorkspaces: this.options.expandWorkspaces ?? true,
       projectOnly: this.options.projectOnly ?? false,
+      trackUnusedImports: this.options.trackUnusedImports ?? true,
     })
     const uniqueConfigPaths = [
       ...new Set(entryConfigs.map((entry) => entry.configPath)),

--- a/src/analyzers/import/references.spec.ts
+++ b/src/analyzers/import/references.spec.ts
@@ -36,4 +36,33 @@ describe('collectModuleReferences', () => {
       ),
     ).toEqual(['./dep.js', './exports.js', './required.js', './dynamic.js'])
   })
+
+  it('collects references without tracking unused imports when no checker is given', () => {
+    const sourceFile = ts.createSourceFile(
+      'fixture.ts',
+      [
+        "import { thing } from './dep.js'",
+        "export * from './exports.js'",
+        'console.log(thing)',
+      ].join('\n'),
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    )
+
+    expect(collectModuleReferences(sourceFile)).toEqual([
+      {
+        specifier: './dep.js',
+        referenceKind: 'import',
+        isTypeOnly: false,
+        unused: false,
+      },
+      {
+        specifier: './exports.js',
+        referenceKind: 'export',
+        isTypeOnly: false,
+        unused: false,
+      },
+    ])
+  })
 })

--- a/src/analyzers/import/references.ts
+++ b/src/analyzers/import/references.ts
@@ -12,10 +12,13 @@ export interface ModuleReference {
 
 export function collectModuleReferences(
   sourceFile: ts.SourceFile,
-  checker: ts.TypeChecker,
+  checker?: ts.TypeChecker,
 ): ModuleReference[] {
   const references = new Map<string, ModuleReference>()
-  const unusedImports = collectUnusedImports(sourceFile, checker)
+  const unusedImports =
+    checker === undefined
+      ? new Map<ts.ImportDeclaration, boolean>()
+      : collectUnusedImports(sourceFile, checker)
 
   function addReference(
     specifier: string,

--- a/src/analyzers/react/index.spec.ts
+++ b/src/analyzers/react/index.spec.ts
@@ -50,7 +50,7 @@ describe('analyzeReactUsage', () => {
     expect(analyzeDependenciesForEntries).toHaveBeenCalledTimes(1)
     expect(analyzeDependenciesForEntries).toHaveBeenCalledWith(
       ['src/a.tsx', 'src/b.tsx'],
-      { cwd: '/repo' },
+      { cwd: '/repo', trackUnusedImports: false },
     )
   })
 })

--- a/src/analyzers/react/index.ts
+++ b/src/analyzers/react/index.ts
@@ -44,10 +44,10 @@ class ReactAnalyzer extends BaseAnalyzer<ReactUsageGraph> {
   }
 
   protected doAnalyze(): ReactUsageGraph {
-    const dependencyGraph = analyzeDependenciesForEntries(
-      this.entryFiles,
-      this.options,
-    )
+    const dependencyGraph = analyzeDependenciesForEntries(this.entryFiles, {
+      ...this.options,
+      trackUnusedImports: false,
+    })
     const fileAnalyses = this.collectFileAnalyses(dependencyGraph)
     const nodes = this.createNodes(fileAnalyses)
     this.attachUsages(fileAnalyses, nodes)

--- a/src/types/analyze-options.ts
+++ b/src/types/analyze-options.ts
@@ -4,4 +4,5 @@ export interface AnalyzeOptions {
   readonly expandWorkspaces?: boolean
   readonly projectOnly?: boolean
   readonly includeBuiltins?: boolean
+  readonly trackUnusedImports?: boolean
 }


### PR DESCRIPTION
## Summary
- skip unused import tracking while building dependency graphs for React analysis
- allow import reference collection to run without a type checker when unused tracking is disabled
- add regression coverage for the React path and the checkerless reference collector

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test:unit -- --runInBand

Refs #36
