### PR TITLE
fix: skip ts program creation for react traversal

### DIFF
--- a/src/analyzers/import/graph.spec.ts
+++ b/src/analyzers/import/graph.spec.ts
@@ -1,9 +1,72 @@
-import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { buildDependencyGraph } from './graph.js'
+const { createProgramMock } = vi.hoisted(() => ({
+  createProgramMock: vi.fn(),
+}))
+
+vi.mock('../../typescript/program.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../typescript/program.js')
+  >('../../typescript/program.js')
+
+  return {
+    ...actual,
+    createProgram: createProgramMock,
+  }
+})
 
 describe('buildDependencyGraph', () => {
-  it('exports a callable graph builder', () => {
+  afterEach(() => {
+    createProgramMock.mockReset()
+  })
+
+  it('exports a callable graph builder', async () => {
+    const { buildDependencyGraph } = await import('./graph.js')
     expect(buildDependencyGraph).toBeTypeOf('function')
+  })
+
+  it('skips TypeScript program creation when unused import tracking is disabled', async () => {
+    const fixtureDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'foresthouse-import-graph-'),
+    )
+    const entryPath = path.join(fixtureDir, 'entry.ts')
+
+    fs.writeFileSync(entryPath, "import './dependency'\n")
+    fs.writeFileSync(
+      path.join(fixtureDir, 'dependency.ts'),
+      'export const dependency = 1\n',
+    )
+
+    createProgramMock.mockImplementation(() => {
+      throw new Error('createProgram should not be called')
+    })
+
+    const { buildDependencyGraph } = await import('./graph.js')
+
+    try {
+      const nodes = buildDependencyGraph(
+        [
+          {
+            entryPath,
+            compilerOptions: {},
+          },
+        ],
+        {
+          cwd: fixtureDir,
+          expandWorkspaces: true,
+          projectOnly: false,
+          trackUnusedImports: false,
+        },
+      )
+
+      expect(createProgramMock).not.toHaveBeenCalled()
+      expect(nodes.has(entryPath)).toBe(true)
+      expect(nodes.size).toBeGreaterThan(0)
+    } finally {
+      fs.rmSync(fixtureDir, { force: true, recursive: true })
+    }
   })
 })

--- a/src/analyzers/import/graph.ts
+++ b/src/analyzers/import/graph.ts
@@ -75,12 +75,10 @@ class DependencyGraphBuilder {
     }
 
     const config = this.getConfigForFile(normalizedPath)
-    const program = this.getProgramForFile(normalizedPath, config)
     const checker = this.options.trackUnusedImports
       ? this.getCheckerForFile(normalizedPath, config)
       : undefined
-    const sourceFile =
-      program.getSourceFile(normalizedPath) ?? createSourceFile(normalizedPath)
+    const sourceFile = this.getSourceFileForFile(normalizedPath, config)
 
     const references = collectModuleReferences(sourceFile, checker)
     const dependencies = references.map((reference) =>
@@ -102,6 +100,20 @@ class DependencyGraphBuilder {
         this.visitFile(dependency.target, entryConfigPath)
       }
     }
+  }
+
+  private getSourceFileForFile(
+    filePath: string,
+    config: import('./resolver.js').ResolverConfigContext,
+  ): ts.SourceFile {
+    if (!this.options.trackUnusedImports) {
+      return createSourceFile(filePath)
+    }
+
+    return (
+      this.getProgramForFile(filePath, config).getSourceFile(filePath) ??
+      createSourceFile(filePath)
+    )
   }
 
   private getConfigForFile(


### PR DESCRIPTION
## Summary
- avoid creating TypeScript programs when unused import tracking is disabled
- reuse direct source file parsing for the React traversal path
- add a regression test for the optimized path

## Verification
- pnpm exec tsc --noEmit
- pnpm exec vitest run src/analyzers/import/graph.spec.ts
- reran the previously failing react-nextjs benchmark under Node 24 without an OOM