### PR TITLE
perf: cache repeated tsconfig lookups

### DIFF
--- a/src/typescript/config.spec.ts
+++ b/src/typescript/config.spec.ts
@@ -70,6 +70,26 @@ describe('loadCompilerOptions', () => {
     expect(loaded.compilerOptions.strict).toBe(true)
     expect(loaded.compilerOptions.jsx).toBe(ts.JsxEmit.ReactJSX)
   })
+
+  it('reuses parsed compiler options for repeated lookups under the same config', () => {
+    const projectDir = createTemporaryDirectory()
+    const srcDir = path.join(projectDir, 'src', 'nested')
+    fs.mkdirSync(srcDir, { recursive: true })
+    writeJson(path.join(projectDir, 'tsconfig.json'), {
+      compilerOptions: {
+        strict: true,
+        target: 'ES2022',
+      },
+    })
+    fs.writeFileSync(path.join(srcDir, 'index.ts'), 'export {}\n')
+
+    const firstLoaded = loadCompilerOptions(srcDir)
+    const secondLoaded = loadCompilerOptions(path.join(projectDir, 'src'))
+
+    expect(firstLoaded.path).toBe(path.join(projectDir, 'tsconfig.json'))
+    expect(secondLoaded.path).toBe(path.join(projectDir, 'tsconfig.json'))
+    expect(secondLoaded).toBe(firstLoaded)
+  })
 })
 
 function createTemporaryDirectory(): string {

--- a/src/typescript/config.ts
+++ b/src/typescript/config.ts
@@ -84,10 +84,7 @@ function findNearestConfig(searchFrom: string): string | undefined {
 
   while (true) {
     const cached = nearestConfigCache.get(currentDirectory)
-    if (
-      cached !== undefined ||
-      nearestConfigCache.has(currentDirectory)
-    ) {
+    if (cached !== undefined || nearestConfigCache.has(currentDirectory)) {
       traversedDirectories.forEach((directory) => {
         nearestConfigCache.set(directory, cached)
       })

--- a/src/typescript/config.ts
+++ b/src/typescript/config.ts
@@ -4,6 +4,8 @@ import ts from 'typescript'
 
 import { createModuleResolutionHost } from './program.js'
 
+const nearestConfigCache = new Map<string, string | undefined>()
+const loadedConfigCache = new Map<string, LoadedConfig>()
 const workspaceRootCache = new Map<string, string | undefined>()
 const workspacePackageCache = new Map<string, ReadonlyMap<string, string>>()
 
@@ -16,15 +18,21 @@ export function loadCompilerOptions(
   searchFrom: string,
   explicitConfigPath?: string,
 ): LoadedConfig {
+  const resolvedSearchFrom = path.resolve(searchFrom)
   const configPath =
     explicitConfigPath === undefined
-      ? findNearestConfig(searchFrom)
-      : path.resolve(searchFrom, explicitConfigPath)
+      ? findNearestConfig(resolvedSearchFrom)
+      : path.resolve(resolvedSearchFrom, explicitConfigPath)
 
   if (configPath === undefined) {
     return {
       compilerOptions: defaultCompilerOptions(),
     }
+  }
+
+  const cached = loadedConfigCache.get(configPath)
+  if (cached !== undefined) {
+    return cached
   }
 
   let fatalDiagnostic: ts.Diagnostic | undefined
@@ -62,30 +70,55 @@ export function loadCompilerOptions(
     )
   }
 
-  return {
+  const loadedConfig = {
     path: configPath,
     compilerOptions: parsed.options,
   }
+  loadedConfigCache.set(configPath, loadedConfig)
+  return loadedConfig
 }
 
 function findNearestConfig(searchFrom: string): string | undefined {
   let currentDirectory = path.resolve(searchFrom)
+  const traversedDirectories: string[] = []
 
   while (true) {
+    const cached = nearestConfigCache.get(currentDirectory)
+    if (
+      cached !== undefined ||
+      nearestConfigCache.has(currentDirectory)
+    ) {
+      traversedDirectories.forEach((directory) => {
+        nearestConfigCache.set(directory, cached)
+      })
+      return cached
+    }
+
+    traversedDirectories.push(currentDirectory)
+
     if (!isInsideNodeModules(currentDirectory)) {
       const tsconfigPath = path.join(currentDirectory, 'tsconfig.json')
       if (ts.sys.fileExists(tsconfigPath)) {
+        traversedDirectories.forEach((directory) => {
+          nearestConfigCache.set(directory, tsconfigPath)
+        })
         return tsconfigPath
       }
 
       const jsconfigPath = path.join(currentDirectory, 'jsconfig.json')
       if (ts.sys.fileExists(jsconfigPath)) {
+        traversedDirectories.forEach((directory) => {
+          nearestConfigCache.set(directory, jsconfigPath)
+        })
         return jsconfigPath
       }
     }
 
     const parentDirectory = path.dirname(currentDirectory)
     if (parentDirectory === currentDirectory) {
+      traversedDirectories.forEach((directory) => {
+        nearestConfigCache.set(directory, undefined)
+      })
       return undefined
     }
 


### PR DESCRIPTION
## Summary
- cache nearest config discovery by directory so repeated lookups reuse the same resolved config path
- cache parsed compiler options by config path to avoid reparsing the same tsconfig/jsconfig file
- add a regression test that verifies repeated lookups under one project reuse the same loaded config

## Validation
- pnpm vitest run src/typescript/config.spec.ts src/analyzers/import/graph.spec.ts --config vitest.unit.config.ts
- pnpm typecheck
- targeted config-loading benchmark: uncached sweep 8959.66ms, cached sweep (cold) 72.81ms, cached sweep (warm) 0.79ms

Closes #87