### PR TITLE
perf: default import output to omit unused dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Options:
   --include-externals  Include packages and Node built-ins in the tree.
   --no-workspaces      Do not expand sibling workspace packages into source subtrees. (default: true)
   --project-only       Restrict traversal to the active tsconfig.json or jsconfig.json project.
-  --no-unused          Omit imports that are never referenced. (default: true)
+  --unused             Include imports that are never referenced.
   --json               Print the dependency tree as JSON.
   -h, --help           Display this message
 ```

--- a/e2e/import.test.ts
+++ b/e2e/import.test.ts
@@ -58,7 +58,7 @@ describe('import command options', () => {
       '--no-workspaces',
       '--project-only',
       '--include-externals',
-      '--no-unused',
+      '--unused',
       '--json',
     ])
 
@@ -70,7 +70,7 @@ describe('import command options', () => {
       expandWorkspaces: false,
       projectOnly: true,
       includeExternals: true,
-      omitUnused: true,
+      omitUnused: false,
       json: true,
     })
   })
@@ -86,7 +86,7 @@ describe('import command options', () => {
       expandWorkspaces: true,
       projectOnly: false,
       includeExternals: false,
-      omitUnused: false,
+      omitUnused: true,
       json: false,
     })
   })

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -81,7 +81,7 @@ class CliMain {
         '--project-only',
         'Restrict traversal to the active tsconfig.json or jsconfig.json project.',
       )
-      .option('--no-unused', 'Omit imports that are never referenced.')
+      .option('--unused', 'Include imports that are never referenced.')
       .option('--json', 'Print the dependency tree as JSON.')
       .action(
         (entryFile: string | undefined, rawOptions: ParsedImportCliOptions) => {
@@ -215,7 +215,7 @@ function normalizeImportCliOptions(
     expandWorkspaces: options.workspaces !== false,
     projectOnly: options.projectOnly === true,
     includeExternals: options.includeExternals === true,
-    omitUnused: options.unused === false,
+    omitUnused: options.unused !== true,
     json: options.json === true,
   }
 }

--- a/src/commands/import.spec.ts
+++ b/src/commands/import.spec.ts
@@ -1,9 +1,41 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
+import { analyzeDependencies } from '../analyzers/import/index.js'
 import { ImportCommand } from './import.js'
+
+vi.mock('../analyzers/import/index.js', () => ({
+  analyzeDependencies: vi.fn(),
+}))
 
 describe('ImportCommand', () => {
   it('exports the import command class', () => {
     expect(ImportCommand).toBeTypeOf('function')
+  })
+
+  it('skips unused import tracking when unused output is omitted', () => {
+    vi.mocked(analyzeDependencies).mockReturnValue({
+      cwd: '/repo',
+      entryId: '/repo/src/main.ts',
+      nodes: new Map(),
+    })
+
+    new ImportCommand({
+      command: 'import',
+      entryFile: 'src/main.ts',
+      cwd: '/repo',
+      configPath: undefined,
+      expandWorkspaces: true,
+      projectOnly: false,
+      includeExternals: false,
+      omitUnused: true,
+      json: false,
+    }).run()
+
+    expect(analyzeDependencies).toHaveBeenCalledWith('src/main.ts', {
+      cwd: '/repo',
+      expandWorkspaces: true,
+      projectOnly: false,
+      trackUnusedImports: false,
+    })
   })
 })

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -10,7 +10,10 @@ export class ImportCommand extends BaseCommand<
   ImportCliOptions
 > {
   protected analyze(): DependencyGraph {
-    return analyzeDependencies(this.options.entryFile, this.getAnalyzeOptions())
+    return analyzeDependencies(this.options.entryFile, {
+      ...this.getAnalyzeOptions(),
+      trackUnusedImports: !this.options.omitUnused,
+    })
   }
 
   protected serialize(graph: DependencyGraph): object {


### PR DESCRIPTION
## Summary
- change the import CLI so unused dependencies are omitted by default and opt-in via `--unused`
- disable unused import analysis work when the command is already omitting unused dependencies
- update tests and help text to match the new default behavior

## Validation
- pnpm run lint
- pnpm typecheck
- pnpm vitest run src/commands/import.spec.ts e2e/import.test.ts --config vitest.config.ts
- pnpm build
- manual timing on the supabase-studio import entry benchmark input: default 1638.43ms, `--unused` 9141.60ms

Closes #92