### PR TITLE
perf: delay checker creation for unused imports

### DIFF
--- a/src/analyzers/import/graph.spec.ts
+++ b/src/analyzers/import/graph.spec.ts
@@ -69,4 +69,46 @@ describe('buildDependencyGraph', () => {
       fs.rmSync(fixtureDir, { force: true, recursive: true })
     }
   })
+
+  it('skips TypeScript program creation for files without trackable import bindings', async () => {
+    const fixtureDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'foresthouse-import-graph-'),
+    )
+    const entryPath = path.join(fixtureDir, 'entry.ts')
+
+    fs.writeFileSync(entryPath, "import './dependency'\n")
+    fs.writeFileSync(
+      path.join(fixtureDir, 'dependency.ts'),
+      'export const dependency = 1\n',
+    )
+
+    createProgramMock.mockImplementation(() => {
+      throw new Error('createProgram should not be called')
+    })
+
+    const { buildDependencyGraph } = await import('./graph.js')
+
+    try {
+      const nodes = buildDependencyGraph(
+        [
+          {
+            entryPath,
+            compilerOptions: {},
+          },
+        ],
+        {
+          cwd: fixtureDir,
+          expandWorkspaces: true,
+          projectOnly: false,
+          trackUnusedImports: true,
+        },
+      )
+
+      expect(createProgramMock).not.toHaveBeenCalled()
+      expect(nodes.has(entryPath)).toBe(true)
+      expect(nodes.size).toBeGreaterThan(0)
+    } finally {
+      fs.rmSync(fixtureDir, { force: true, recursive: true })
+    }
+  })
 })

--- a/src/analyzers/import/graph.ts
+++ b/src/analyzers/import/graph.ts
@@ -11,6 +11,7 @@ import { createProgram, createSourceFile } from '../../typescript/program.js'
 import { normalizeFilePath } from '../../utils/normalize-file-path.js'
 import { collectModuleReferences } from './references.js'
 import { resolveDependency } from './resolver.js'
+import { hasTrackableImportBindings } from './unused.js'
 
 export function buildDependencyGraph(
   entryConfigs: readonly EntryConfig[],
@@ -75,10 +76,16 @@ class DependencyGraphBuilder {
     }
 
     const config = this.getConfigForFile(normalizedPath)
-    const checker = this.options.trackUnusedImports
+    const syntaxSourceFile = createSourceFile(normalizedPath)
+    const shouldTrackUnusedImports =
+      this.options.trackUnusedImports &&
+      hasTrackableImportBindings(syntaxSourceFile)
+    const checker = shouldTrackUnusedImports
       ? this.getCheckerForFile(normalizedPath, config)
       : undefined
-    const sourceFile = this.getSourceFileForFile(normalizedPath, config)
+    const sourceFile = shouldTrackUnusedImports
+      ? this.getSourceFileForFile(normalizedPath, config)
+      : syntaxSourceFile
 
     const references = collectModuleReferences(sourceFile, checker)
     const dependencies = references.map((reference) =>

--- a/src/analyzers/import/unused.spec.ts
+++ b/src/analyzers/import/unused.spec.ts
@@ -1,7 +1,33 @@
 import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 
-import { collectUnusedImports } from './unused.js'
+import { collectUnusedImports, hasTrackableImportBindings } from './unused.js'
+
+describe('hasTrackableImportBindings', () => {
+  it('ignores side-effect-only imports', () => {
+    const sourceFile = ts.createSourceFile(
+      'fixture.ts',
+      "import './dep.js'\n",
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    )
+
+    expect(hasTrackableImportBindings(sourceFile)).toBe(false)
+  })
+
+  it('detects import declarations with bindings', () => {
+    const sourceFile = ts.createSourceFile(
+      'fixture.ts',
+      "import { thing } from './dep.js'\n",
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    )
+
+    expect(hasTrackableImportBindings(sourceFile)).toBe(true)
+  })
+})
 
 describe('collectUnusedImports', () => {
   it('marks tracked imports that are never referenced', () => {

--- a/src/analyzers/import/unused.ts
+++ b/src/analyzers/import/unused.ts
@@ -1,5 +1,15 @@
 import ts from 'typescript'
 
+export function hasTrackableImportBindings(sourceFile: ts.SourceFile): boolean {
+  return sourceFile.statements.some((statement) => {
+    return (
+      ts.isImportDeclaration(statement) &&
+      statement.importClause !== undefined &&
+      getImportBindingIdentifiers(statement.importClause).length > 0
+    )
+  })
+}
+
 export function collectUnusedImports(
   sourceFile: ts.SourceFile,
   checker: ts.TypeChecker,


### PR DESCRIPTION
## Summary
- parse each file once up front and only create a TypeScript program/checker when the file has import bindings that can affect unused import output
- keep side-effect-only files on the syntax-only path instead of paying checker setup cost
- add unit coverage for the helper and for graph building without checker creation on side-effect-only imports

## Validation
- pnpm run lint
- pnpm typecheck
- pnpm vitest run src/analyzers/import/graph.spec.ts src/analyzers/import/unused.spec.ts --config vitest.unit.config.ts
- pnpm build
- manual timing on the supabase-studio import entry benchmark input with `--unused`: baseline 9313.33ms, current 8120.19ms
- manual timing on the same input without `--unused`: baseline 1345.02ms, current 1207.29ms

Closes #91