### PR TITLE
docs: add benchmark results to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,106 @@ Common examples:
 - `foresthouse deps ./packages/a`
 - `foresthouse deps . --diff origin/dev...HEAD`
 
+## Benchmark
+
+<details>
+<summary>Environment</summary>
+
+| Metric   | Value        |
+| -------- | ------------ |
+| Platform | darwin arm64 |
+| Node     | v24.14.0     |
+| CPU      | Apple M2 Max |
+| Cores    | 12           |
+| Memory   | 32.0 GB      |
+
+</details>
+
+<details>
+<summary><code>foresthouse deps</code></summary>
+
+| Target    | Options | Project         | LOC     | Status  | Median   | P95      | Note                                     |
+| --------- | ------- | --------------- | ------- | ------- | -------- | -------- | ---------------------------------------- |
+| directory | (none)  | supabase-studio | 493,979 | ok      | 184.37ms | 216.11ms |                                          |
+| directory | (none)  | cal-com-web     | 218,466 | ok      | 182.89ms | 196.84ms |                                          |
+| directory | (none)  | outline-app     | 87,658  | ok      | 171.15ms | 172.83ms |                                          |
+| directory | (none)  | dub-web         | 345,285 | ok      | 181.13ms | 186.52ms |                                          |
+| directory | (none)  | commerce        | 3,968   | skipped | -        | -        | Package manifest is missing a valid name |
+| directory | (none)  | formbricks-web  | 247,895 | ok      | 171.78ms | 181.43ms |                                          |
+| directory | (none)  | platforms       | 1,308   | skipped | -        | -        | Package manifest is missing a valid name |
+| directory | (none)  | t3-nextjs       | 711     | ok      | 173.51ms | 184.11ms |                                          |
+
+</details>
+
+<details>
+<summary><code>foresthouse import</code></summary>
+
+| Target | Options           | Project         | LOC     | Status | Median    | P95       |
+| ------ | ----------------- | --------------- | ------- | ------ | --------- | --------- |
+| entry  | (none)            | supabase-studio | 493,979 | ok     | 1014.23ms | 1413.45ms |
+| entry  | `--project-only`  | supabase-studio | 493,979 | ok     | 782.13ms  | 838.64ms  |
+| entry  | `--no-workspaces` | supabase-studio | 493,979 | ok     | 782.02ms  | 833.00ms  |
+| entry  | (none)            | cal-com-web     | 218,466 | ok     | 1042.08ms | 1109.40ms |
+| entry  | `--project-only`  | cal-com-web     | 218,466 | ok     | 284.00ms  | 426.76ms  |
+| entry  | `--no-workspaces` | cal-com-web     | 218,466 | ok     | 250.25ms  | 320.31ms  |
+| entry  | (none)            | outline-app     | 87,658  | ok     | 600.36ms  | 840.67ms  |
+| entry  | (none)            | dub-web         | 345,285 | ok     | 259.89ms  | 309.41ms  |
+| entry  | `--project-only`  | dub-web         | 345,285 | ok     | 253.14ms  | 254.04ms  |
+| entry  | `--no-workspaces` | dub-web         | 345,285 | ok     | 257.75ms  | 259.07ms  |
+| entry  | (none)            | commerce        | 3,968   | ok     | 199.93ms  | 205.46ms  |
+| entry  | (none)            | formbricks-web  | 247,895 | ok     | 333.93ms  | 405.91ms  |
+| entry  | `--project-only`  | formbricks-web  | 247,895 | ok     | 313.35ms  | 342.89ms  |
+| entry  | `--no-workspaces` | formbricks-web  | 247,895 | ok     | 296.93ms  | 355.40ms  |
+| entry  | (none)            | platforms       | 1,308   | ok     | 189.81ms  | 199.19ms  |
+| entry  | (none)            | t3-nextjs       | 711     | ok     | 217.94ms  | 247.73ms  |
+| entry  | `--project-only`  | t3-nextjs       | 711     | ok     | 202.47ms  | 215.69ms  |
+| entry  | `--no-workspaces` | t3-nextjs       | 711     | ok     | 200.04ms  | 200.67ms  |
+
+</details>
+
+<details>
+<summary><code>foresthouse react</code></summary>
+
+| Target | Options           | Project         | LOC     | Status | Median    | P95       |
+| ------ | ----------------- | --------------- | ------- | ------ | --------- | --------- |
+| entry  | (none)            | supabase-studio | 493,979 | ok     | 1333.58ms | 1494.41ms |
+| entry  | `--project-only`  | supabase-studio | 493,979 | ok     | 996.02ms  | 1059.62ms |
+| entry  | `--no-workspaces` | supabase-studio | 493,979 | ok     | 1005.37ms | 1137.48ms |
+| nextjs | (none)            | supabase-studio | 493,979 | ok     | 3059.37ms | 3534.34ms |
+| nextjs | `--project-only`  | supabase-studio | 493,979 | ok     | 2602.21ms | 2716.90ms |
+| nextjs | `--no-workspaces` | supabase-studio | 493,979 | ok     | 2716.09ms | 3007.85ms |
+| entry  | (none)            | cal-com-web     | 218,466 | ok     | 1832.85ms | 1859.41ms |
+| entry  | `--project-only`  | cal-com-web     | 218,466 | ok     | 244.83ms  | 347.60ms  |
+| entry  | `--no-workspaces` | cal-com-web     | 218,466 | ok     | 242.31ms  | 249.87ms  |
+| nextjs | (none)            | cal-com-web     | 218,466 | ok     | 4418.86ms | 5438.14ms |
+| nextjs | `--project-only`  | cal-com-web     | 218,466 | ok     | 1400.78ms | 1498.16ms |
+| nextjs | `--no-workspaces` | cal-com-web     | 218,466 | ok     | 1405.46ms | 1452.13ms |
+| entry  | (none)            | outline-app     | 87,658  | ok     | 931.17ms  | 946.86ms  |
+| entry  | (none)            | dub-web         | 345,285 | ok     | 265.47ms  | 273.70ms  |
+| entry  | `--project-only`  | dub-web         | 345,285 | ok     | 266.99ms  | 268.79ms  |
+| entry  | `--no-workspaces` | dub-web         | 345,285 | ok     | 265.71ms  | 276.33ms  |
+| nextjs | (none)            | dub-web         | 345,285 | ok     | 1568.90ms | 1964.85ms |
+| nextjs | `--project-only`  | dub-web         | 345,285 | ok     | 1589.73ms | 1624.88ms |
+| nextjs | `--no-workspaces` | dub-web         | 345,285 | ok     | 1507.13ms | 1859.47ms |
+| entry  | (none)            | commerce        | 3,968   | ok     | 213.42ms  | 218.10ms  |
+| nextjs | (none)            | commerce        | 3,968   | ok     | 222.09ms  | 227.03ms  |
+| entry  | (none)            | formbricks-web  | 247,895 | ok     | 381.40ms  | 391.71ms  |
+| entry  | `--project-only`  | formbricks-web  | 247,895 | ok     | 321.40ms  | 331.36ms  |
+| entry  | `--no-workspaces` | formbricks-web  | 247,895 | ok     | 323.95ms  | 327.12ms  |
+| nextjs | (none)            | formbricks-web  | 247,895 | ok     | 1118.63ms | 1303.93ms |
+| nextjs | `--project-only`  | formbricks-web  | 247,895 | ok     | 1041.12ms | 1062.49ms |
+| nextjs | `--no-workspaces` | formbricks-web  | 247,895 | ok     | 1055.21ms | 1107.24ms |
+| entry  | (none)            | platforms       | 1,308   | ok     | 201.30ms  | 205.59ms  |
+| nextjs | (none)            | platforms       | 1,308   | ok     | 202.98ms  | 209.47ms  |
+| entry  | (none)            | t3-nextjs       | 711     | ok     | 231.38ms  | 234.95ms  |
+| entry  | `--project-only`  | t3-nextjs       | 711     | ok     | 212.96ms  | 214.89ms  |
+| entry  | `--no-workspaces` | t3-nextjs       | 711     | ok     | 212.09ms  | 218.98ms  |
+| nextjs | (none)            | t3-nextjs       | 711     | ok     | 232.97ms  | 233.53ms  |
+| nextjs | `--project-only`  | t3-nextjs       | 711     | ok     | 211.67ms  | 215.33ms  |
+| nextjs | `--no-workspaces` | t3-nextjs       | 711     | ok     | 211.65ms  | 215.49ms  |
+
+</details>
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -147,98 +147,114 @@ Common examples:
 <details>
 <summary>Environment</summary>
 
+```
++----------+--------------+
 | Metric   | Value        |
-| -------- | ------------ |
++----------+--------------+
 | Platform | darwin arm64 |
 | Node     | v24.14.0     |
 | CPU      | Apple M2 Max |
 | Cores    | 12           |
 | Memory   | 32.0 GB      |
++----------+--------------+
+```
 
 </details>
 
 <details>
 <summary><code>foresthouse deps</code></summary>
 
-| Target    | Options | Project         | LOC     | Status  | Median   | P95      | Note                                     |
-| --------- | ------- | --------------- | ------- | ------- | -------- | -------- | ---------------------------------------- |
-| directory | (none)  | supabase-studio | 493,979 | ok      | 184.37ms | 216.11ms |                                          |
-| directory | (none)  | cal-com-web     | 218,466 | ok      | 182.89ms | 196.84ms |                                          |
-| directory | (none)  | outline-app     | 87,658  | ok      | 171.15ms | 172.83ms |                                          |
-| directory | (none)  | dub-web         | 345,285 | ok      | 181.13ms | 186.52ms |                                          |
-| directory | (none)  | commerce        | 3,968   | skipped | -        | -        | Package manifest is missing a valid name |
-| directory | (none)  | formbricks-web  | 247,895 | ok      | 171.78ms | 181.43ms |                                          |
-| directory | (none)  | platforms       | 1,308   | skipped | -        | -        | Package manifest is missing a valid name |
-| directory | (none)  | t3-nextjs       | 711     | ok      | 173.51ms | 184.11ms |                                          |
+```
++-----------+---------+-----------------+---------+---------+----------+----------+-------------------------------------------+
+| Target    | Options | Project         | LOC     | Status  | Median   | P95      | Note                                      |
++-----------+---------+-----------------+---------+---------+----------+----------+-------------------------------------------+
+| directory | (none)  | supabase-studio | 493,979 | ok      | 184.37ms | 216.11ms |                                           |
+| directory | (none)  | cal-com-web     | 218,466 | ok      | 182.89ms | 196.84ms |                                           |
+| directory | (none)  | outline-app     | 87,658  | ok      | 171.15ms | 172.83ms |                                           |
+| directory | (none)  | dub-web         | 345,285 | ok      | 181.13ms | 186.52ms |                                           |
+| directory | (none)  | commerce        | 3,968   | skipped | -        | -        | Package manifest is missing a valid name. |
+| directory | (none)  | formbricks-web  | 247,895 | ok      | 171.78ms | 181.43ms |                                           |
+| directory | (none)  | platforms       | 1,308   | skipped | -        | -        | Package manifest is missing a valid name. |
+| directory | (none)  | t3-nextjs       | 711     | ok      | 173.51ms | 184.11ms |                                           |
++-----------+---------+-----------------+---------+---------+----------+----------+-------------------------------------------+
+```
 
 </details>
 
 <details>
 <summary><code>foresthouse import</code></summary>
 
-| Target | Options           | Project         | LOC     | Status | Median    | P95       |
-| ------ | ----------------- | --------------- | ------- | ------ | --------- | --------- |
-| entry  | (none)            | supabase-studio | 493,979 | ok     | 1014.23ms | 1413.45ms |
-| entry  | `--project-only`  | supabase-studio | 493,979 | ok     | 782.13ms  | 838.64ms  |
-| entry  | `--no-workspaces` | supabase-studio | 493,979 | ok     | 782.02ms  | 833.00ms  |
-| entry  | (none)            | cal-com-web     | 218,466 | ok     | 1042.08ms | 1109.40ms |
-| entry  | `--project-only`  | cal-com-web     | 218,466 | ok     | 284.00ms  | 426.76ms  |
-| entry  | `--no-workspaces` | cal-com-web     | 218,466 | ok     | 250.25ms  | 320.31ms  |
-| entry  | (none)            | outline-app     | 87,658  | ok     | 600.36ms  | 840.67ms  |
-| entry  | (none)            | dub-web         | 345,285 | ok     | 259.89ms  | 309.41ms  |
-| entry  | `--project-only`  | dub-web         | 345,285 | ok     | 253.14ms  | 254.04ms  |
-| entry  | `--no-workspaces` | dub-web         | 345,285 | ok     | 257.75ms  | 259.07ms  |
-| entry  | (none)            | commerce        | 3,968   | ok     | 199.93ms  | 205.46ms  |
-| entry  | (none)            | formbricks-web  | 247,895 | ok     | 333.93ms  | 405.91ms  |
-| entry  | `--project-only`  | formbricks-web  | 247,895 | ok     | 313.35ms  | 342.89ms  |
-| entry  | `--no-workspaces` | formbricks-web  | 247,895 | ok     | 296.93ms  | 355.40ms  |
-| entry  | (none)            | platforms       | 1,308   | ok     | 189.81ms  | 199.19ms  |
-| entry  | (none)            | t3-nextjs       | 711     | ok     | 217.94ms  | 247.73ms  |
-| entry  | `--project-only`  | t3-nextjs       | 711     | ok     | 202.47ms  | 215.69ms  |
-| entry  | `--no-workspaces` | t3-nextjs       | 711     | ok     | 200.04ms  | 200.67ms  |
+```
++--------+-----------------+-----------------+---------+--------+-----------+-----------+------+
+| Target | Options         | Project         | LOC     | Status | Median    | P95       | Note |
++--------+-----------------+-----------------+---------+--------+-----------+-----------+------+
+| entry  | (none)          | supabase-studio | 493,979 | ok     | 1014.23ms | 1413.45ms |      |
+| entry  | --project-only  | supabase-studio | 493,979 | ok     | 782.13ms  | 838.64ms  |      |
+| entry  | --no-workspaces | supabase-studio | 493,979 | ok     | 782.02ms  | 833.00ms  |      |
+| entry  | (none)          | cal-com-web     | 218,466 | ok     | 1042.08ms | 1109.40ms |      |
+| entry  | --project-only  | cal-com-web     | 218,466 | ok     | 284.00ms  | 426.76ms  |      |
+| entry  | --no-workspaces | cal-com-web     | 218,466 | ok     | 250.25ms  | 320.31ms  |      |
+| entry  | (none)          | outline-app     | 87,658  | ok     | 600.36ms  | 840.67ms  |      |
+| entry  | (none)          | dub-web         | 345,285 | ok     | 259.89ms  | 309.41ms  |      |
+| entry  | --project-only  | dub-web         | 345,285 | ok     | 253.14ms  | 254.04ms  |      |
+| entry  | --no-workspaces | dub-web         | 345,285 | ok     | 257.75ms  | 259.07ms  |      |
+| entry  | (none)          | commerce        | 3,968   | ok     | 199.93ms  | 205.46ms  |      |
+| entry  | (none)          | formbricks-web  | 247,895 | ok     | 333.93ms  | 405.91ms  |      |
+| entry  | --project-only  | formbricks-web  | 247,895 | ok     | 313.35ms  | 342.89ms  |      |
+| entry  | --no-workspaces | formbricks-web  | 247,895 | ok     | 296.93ms  | 355.40ms  |      |
+| entry  | (none)          | platforms       | 1,308   | ok     | 189.81ms  | 199.19ms  |      |
+| entry  | (none)          | t3-nextjs       | 711     | ok     | 217.94ms  | 247.73ms  |      |
+| entry  | --project-only  | t3-nextjs       | 711     | ok     | 202.47ms  | 215.69ms  |      |
+| entry  | --no-workspaces | t3-nextjs       | 711     | ok     | 200.04ms  | 200.67ms  |      |
++--------+-----------------+-----------------+---------+--------+-----------+-----------+------+
+```
 
 </details>
 
 <details>
 <summary><code>foresthouse react</code></summary>
 
-| Target | Options           | Project         | LOC     | Status | Median    | P95       |
-| ------ | ----------------- | --------------- | ------- | ------ | --------- | --------- |
-| entry  | (none)            | supabase-studio | 493,979 | ok     | 1333.58ms | 1494.41ms |
-| entry  | `--project-only`  | supabase-studio | 493,979 | ok     | 996.02ms  | 1059.62ms |
-| entry  | `--no-workspaces` | supabase-studio | 493,979 | ok     | 1005.37ms | 1137.48ms |
-| nextjs | (none)            | supabase-studio | 493,979 | ok     | 3059.37ms | 3534.34ms |
-| nextjs | `--project-only`  | supabase-studio | 493,979 | ok     | 2602.21ms | 2716.90ms |
-| nextjs | `--no-workspaces` | supabase-studio | 493,979 | ok     | 2716.09ms | 3007.85ms |
-| entry  | (none)            | cal-com-web     | 218,466 | ok     | 1832.85ms | 1859.41ms |
-| entry  | `--project-only`  | cal-com-web     | 218,466 | ok     | 244.83ms  | 347.60ms  |
-| entry  | `--no-workspaces` | cal-com-web     | 218,466 | ok     | 242.31ms  | 249.87ms  |
-| nextjs | (none)            | cal-com-web     | 218,466 | ok     | 4418.86ms | 5438.14ms |
-| nextjs | `--project-only`  | cal-com-web     | 218,466 | ok     | 1400.78ms | 1498.16ms |
-| nextjs | `--no-workspaces` | cal-com-web     | 218,466 | ok     | 1405.46ms | 1452.13ms |
-| entry  | (none)            | outline-app     | 87,658  | ok     | 931.17ms  | 946.86ms  |
-| entry  | (none)            | dub-web         | 345,285 | ok     | 265.47ms  | 273.70ms  |
-| entry  | `--project-only`  | dub-web         | 345,285 | ok     | 266.99ms  | 268.79ms  |
-| entry  | `--no-workspaces` | dub-web         | 345,285 | ok     | 265.71ms  | 276.33ms  |
-| nextjs | (none)            | dub-web         | 345,285 | ok     | 1568.90ms | 1964.85ms |
-| nextjs | `--project-only`  | dub-web         | 345,285 | ok     | 1589.73ms | 1624.88ms |
-| nextjs | `--no-workspaces` | dub-web         | 345,285 | ok     | 1507.13ms | 1859.47ms |
-| entry  | (none)            | commerce        | 3,968   | ok     | 213.42ms  | 218.10ms  |
-| nextjs | (none)            | commerce        | 3,968   | ok     | 222.09ms  | 227.03ms  |
-| entry  | (none)            | formbricks-web  | 247,895 | ok     | 381.40ms  | 391.71ms  |
-| entry  | `--project-only`  | formbricks-web  | 247,895 | ok     | 321.40ms  | 331.36ms  |
-| entry  | `--no-workspaces` | formbricks-web  | 247,895 | ok     | 323.95ms  | 327.12ms  |
-| nextjs | (none)            | formbricks-web  | 247,895 | ok     | 1118.63ms | 1303.93ms |
-| nextjs | `--project-only`  | formbricks-web  | 247,895 | ok     | 1041.12ms | 1062.49ms |
-| nextjs | `--no-workspaces` | formbricks-web  | 247,895 | ok     | 1055.21ms | 1107.24ms |
-| entry  | (none)            | platforms       | 1,308   | ok     | 201.30ms  | 205.59ms  |
-| nextjs | (none)            | platforms       | 1,308   | ok     | 202.98ms  | 209.47ms  |
-| entry  | (none)            | t3-nextjs       | 711     | ok     | 231.38ms  | 234.95ms  |
-| entry  | `--project-only`  | t3-nextjs       | 711     | ok     | 212.96ms  | 214.89ms  |
-| entry  | `--no-workspaces` | t3-nextjs       | 711     | ok     | 212.09ms  | 218.98ms  |
-| nextjs | (none)            | t3-nextjs       | 711     | ok     | 232.97ms  | 233.53ms  |
-| nextjs | `--project-only`  | t3-nextjs       | 711     | ok     | 211.67ms  | 215.33ms  |
-| nextjs | `--no-workspaces` | t3-nextjs       | 711     | ok     | 211.65ms  | 215.49ms  |
+```
++--------+-----------------+-----------------+---------+--------+-----------+-----------+------+
+| Target | Options         | Project         | LOC     | Status | Median    | P95       | Note |
++--------+-----------------+-----------------+---------+--------+-----------+-----------+------+
+| entry  | (none)          | supabase-studio | 493,979 | ok     | 1333.58ms | 1494.41ms |      |
+| entry  | --project-only  | supabase-studio | 493,979 | ok     | 996.02ms  | 1059.62ms |      |
+| entry  | --no-workspaces | supabase-studio | 493,979 | ok     | 1005.37ms | 1137.48ms |      |
+| nextjs | (none)          | supabase-studio | 493,979 | ok     | 3059.37ms | 3534.34ms |      |
+| nextjs | --project-only  | supabase-studio | 493,979 | ok     | 2602.21ms | 2716.90ms |      |
+| nextjs | --no-workspaces | supabase-studio | 493,979 | ok     | 2716.09ms | 3007.85ms |      |
+| entry  | (none)          | cal-com-web     | 218,466 | ok     | 1832.85ms | 1859.41ms |      |
+| entry  | --project-only  | cal-com-web     | 218,466 | ok     | 244.83ms  | 347.60ms  |      |
+| entry  | --no-workspaces | cal-com-web     | 218,466 | ok     | 242.31ms  | 249.87ms  |      |
+| nextjs | (none)          | cal-com-web     | 218,466 | ok     | 4418.86ms | 5438.14ms |      |
+| nextjs | --project-only  | cal-com-web     | 218,466 | ok     | 1400.78ms | 1498.16ms |      |
+| nextjs | --no-workspaces | cal-com-web     | 218,466 | ok     | 1405.46ms | 1452.13ms |      |
+| entry  | (none)          | outline-app     | 87,658  | ok     | 931.17ms  | 946.86ms  |      |
+| entry  | (none)          | dub-web         | 345,285 | ok     | 265.47ms  | 273.70ms  |      |
+| entry  | --project-only  | dub-web         | 345,285 | ok     | 266.99ms  | 268.79ms  |      |
+| entry  | --no-workspaces | dub-web         | 345,285 | ok     | 265.71ms  | 276.33ms  |      |
+| nextjs | (none)          | dub-web         | 345,285 | ok     | 1568.90ms | 1964.85ms |      |
+| nextjs | --project-only  | dub-web         | 345,285 | ok     | 1589.73ms | 1624.88ms |      |
+| nextjs | --no-workspaces | dub-web         | 345,285 | ok     | 1507.13ms | 1859.47ms |      |
+| entry  | (none)          | commerce        | 3,968   | ok     | 213.42ms  | 218.10ms  |      |
+| nextjs | (none)          | commerce        | 3,968   | ok     | 222.09ms  | 227.03ms  |      |
+| entry  | (none)          | formbricks-web  | 247,895 | ok     | 381.40ms  | 391.71ms  |      |
+| entry  | --project-only  | formbricks-web  | 247,895 | ok     | 321.40ms  | 331.36ms  |      |
+| entry  | --no-workspaces | formbricks-web  | 247,895 | ok     | 323.95ms  | 327.12ms  |      |
+| nextjs | (none)          | formbricks-web  | 247,895 | ok     | 1118.63ms | 1303.93ms |      |
+| nextjs | --project-only  | formbricks-web  | 247,895 | ok     | 1041.12ms | 1062.49ms |      |
+| nextjs | --no-workspaces | formbricks-web  | 247,895 | ok     | 1055.21ms | 1107.24ms |      |
+| entry  | (none)          | platforms       | 1,308   | ok     | 201.30ms  | 205.59ms  |      |
+| nextjs | (none)          | platforms       | 1,308   | ok     | 202.98ms  | 209.47ms  |      |
+| entry  | (none)          | t3-nextjs       | 711     | ok     | 231.38ms  | 234.95ms  |      |
+| entry  | --project-only  | t3-nextjs       | 711     | ok     | 212.96ms  | 214.89ms  |      |
+| entry  | --no-workspaces | t3-nextjs       | 711     | ok     | 212.09ms  | 218.98ms  |      |
+| nextjs | (none)          | t3-nextjs       | 711     | ok     | 232.97ms  | 233.53ms  |      |
+| nextjs | --project-only  | t3-nextjs       | 711     | ok     | 211.67ms  | 215.33ms  |      |
+| nextjs | --no-workspaces | t3-nextjs       | 711     | ok     | 211.65ms  | 215.49ms  |      |
++--------+-----------------+-----------------+---------+--------+-----------+-----------+------+
+```
 
 </details>
 


### PR DESCRIPTION
## Summary
- README에 Benchmark 섹션 추가 (`deps`, `import`, `react` 커맨드별 결과)
- 내용이 길어 각 커맨드 결과를 collapsible `<details>` 블록으로 구성
- 벤치마크 환경 정보(Platform, Node, CPU, Cores, Memory) 포함

## Test plan
- [ ] GitHub에서 README 렌더링 확인 (collapsible 섹션 열림/닫힘)
- [ ] 마크다운 테이블 정렬 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)