### PR TITLE
fix(react): resolve default re-export bindings from imported identifiers

### DIFF
--- a/src/analyzers/react/bindings.ts
+++ b/src/analyzers/react/bindings.ts
@@ -42,7 +42,13 @@ export function collectImportsAndExports(
       collectExportAllBindings(statement, sourceDependencies, exportAllBindings)
       return
     case 'ExportDefaultDeclaration':
-      collectDefaultExport(statement, symbolsByName, exportsByName)
+      collectDefaultExport(
+        statement,
+        symbolsByName,
+        importsByLocalName,
+        exportsByName,
+        reExportBindingsByName,
+      )
       return
     default:
       return
@@ -198,7 +204,9 @@ function collectExportAllBindings(
 function collectDefaultExport(
   declaration: ExportDefaultDeclaration,
   symbolsByName: ReadonlyMap<string, PendingReactUsageNode>,
+  importsByLocalName: ReadonlyMap<string, ImportBinding>,
   exportsByName: Map<string, string>,
+  reExportBindingsByName: Map<string, ImportBinding>,
 ): void {
   if (
     declaration.declaration.type === 'FunctionDeclaration' ||
@@ -212,12 +220,15 @@ function collectDefaultExport(
   }
 
   if (declaration.declaration.type === 'Identifier') {
-    addExportBinding(
-      declaration.declaration.name,
-      'default',
-      symbolsByName,
-      exportsByName,
-    )
+    const localName = declaration.declaration.name
+    addExportBinding(localName, 'default', symbolsByName, exportsByName)
+
+    if (!exportsByName.has('default')) {
+      const importBinding = importsByLocalName.get(localName)
+      if (importBinding !== undefined) {
+        reExportBindingsByName.set('default', importBinding)
+      }
+    }
     return
   }
 


### PR DESCRIPTION
## Summary

- Fix `export default ImportedIdentifier` pattern not being recognized as a re-export, causing components imported through barrel files to be missing from the react usage tree
- Pass `importsByLocalName` and `reExportBindingsByName` into `collectDefaultExport` so it can fall back to creating a re-export binding when the exported identifier is not a locally defined symbol

## Details

When a barrel file re-exports like:
```ts
import Footer from './Footer'
export default Footer
```

`collectDefaultExport` called `addExportBinding('Footer', 'default', symbolsByName, ...)`, but `Footer` only existed in `importsByLocalName`, not `symbolsByName`. `addExportBinding` silently returned, and the default export was never registered — making `<Footer />` invisible in the tree.

The fix adds a fallback: if `addExportBinding` didn't register anything (the identifier isn't local), check `importsByLocalName` and create a `reExportBinding` instead.

## Test plan

- [x] All existing unit tests pass (56/56)
- [x] All existing e2e tests pass (55/55)
- [x] Manually verified: `<Footer />` now appears in TransparentLayout tree when analyzing a real Next.js project

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)