### PR TITLE
fix(react): detect JSX rendered inside useCallback and other nested functions

### DIFF
--- a/src/analyzers/react/walk.ts
+++ b/src/analyzers/react/walk.ts
@@ -64,7 +64,7 @@ function walkChild(
     return
   }
 
-  walkNode(value, visit, false)
+  walkNode(value, visit, allowNestedFunctions)
 }
 
 export function isNode(value: unknown): value is Node {


### PR DESCRIPTION
## Summary

- Fix components rendered inside `useCallback`, `useMemo`, and other callback patterns being invisible in the react usage tree
- Propagate `allowNestedFunctions` flag through `walkChild` instead of hardcoding `false`

## Details

The AST walker in `walk.ts` line 67 had:
```typescript
walkNode(value, visit, false)  // always stops at nested functions
```

Changed to:
```typescript
walkNode(value, visit, allowNestedFunctions)  // propagate the flag
```

`walkReactUsageTree` starts with `allowNestedFunctions=true`, but `walkChild` was dropping it to `false` on the first recursive call. This meant any function body (arrow functions in `useCallback`, `useMemo`, event handlers, `.map()` callbacks) was never entered.

**Before:** Components inside callbacks were missing
```
<GlobalNavigation />
├─ <SlideMenu />          ← empty, no children detected
└─ useCallback() [hook]
```

**After:** All nested JSX is now detected
```
<GlobalNavigation />
├─ <NavigationPopupMenu />    ← from renderNavigationMenu callback
├─ <NavigationSectionMenu />  ← from renderNavigationMenu callback
├─ <SlideMenu />
│  ├─ <HomeSlideMenuItem />       ← from renderSlideMenuItem callback
│  ├─ <LinkSlideMenuItem />       ← from renderSlideMenuItem callback
│  └─ <SectionSlideMenuItem />    ← from renderSlideMenuItem callback
└─ useCallback() [hook]
```

Note: `entries.ts` uses its own walking logic and is not affected by this change.

## Test plan

- [x] All unit tests pass (56/56)
- [x] All e2e tests pass (55/55)
- [x] Manually verified with a real Next.js project: `useCallback` render patterns now detected

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)