### PR TITLE
feat(react): add usage diff and benchmark coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,19 @@ Options:
   -h, --help       Display this message
 ```
 
+React diff mode compares React usage graphs rather than raw file text diffs. A single ref like `--diff HEAD~3` compares that tree to the current working tree, while ranges such as `HEAD~3..HEAD` or `origin/dev...HEAD` compare two committed Git trees.
+
+Example React diff output:
+
+```text
+~ apps/site/pages/index.tsx:21:45
+~ <Home /> [component] (apps/site/pages/index.tsx)
+└─ ~ <Hero /> [component] (apps/site/src/features/Main/Hero/Hero.tsx)
+   └─ + useForm() [hook] (react-hook-form)
+```
+
+In this example, the page entry itself is unchanged as source text, but its reachable React graph changed because `<Hero />` started calling `useForm()`.
+
 ### `foresthouse deps --help`
 
 Analyzes package-level dependency trees for both single-package projects and monorepos. Use `--diff` to show only dependency changes relative to a Git ref or range.
@@ -140,6 +153,7 @@ Common examples:
 - `foresthouse import --entry src/main.ts --cwd test/fixtures/basic`
 - `foresthouse react src/App.tsx`
 - `foresthouse react src/App.tsx --diff origin/dev...HEAD`
+- `foresthouse react pages/index.tsx --cwd . --diff HEAD~3..HEAD`
 - `foresthouse react --nextjs --cwd .`
 - `foresthouse deps .`
 - `foresthouse deps ./packages/a`
@@ -273,3 +287,4 @@ pnpm run check
 
 - Unit tests live next to source files as `src/**/*.spec.ts`.
 - End-to-end command tests live under `e2e/`.
+- Benchmarks live next to analyzers as `src/**/*.bench.ts` and run with `pnpm exec vitest bench --run --config vitest.bench.config.ts`.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ bunx foresthouse --help
 - Honors the nearest `tsconfig.json` or `jsconfig.json`, including `baseUrl` and `paths`
 - Expands sibling workspace packages by default, including their own `tsconfig` alias rules
 - Analyzes React component and hook usage trees from explicit entry files or inferred Next.js app and pages routes
+- Shows React tree changes relative to a Git ref or range with `foresthouse react --diff`
 - Reads `package.json` manifests to show package-level dependency trees for single packages and monorepos
 - Shows dependency-tree changes relative to a Git ref or range with `foresthouse deps --diff`
 - Prints an ASCII tree by default, or JSON with `--json`
@@ -58,7 +59,7 @@ Options:
 ### Commands
 
 - `foresthouse import <entry-file>`: analyzes a JavaScript or TypeScript entry file and prints a dependency tree by following imports, re-exports, `require()`, and dynamic `import()`.
-- `foresthouse react [entry-file]`: analyzes React component, hook, and render relationships and prints a React usage tree. It also supports automatic Next.js entry discovery with `--nextjs`.
+- `foresthouse react [entry-file]`: analyzes React component, hook, and render relationships and prints a React usage tree. It also supports automatic Next.js entry discovery with `--nextjs`, plus Git-based tree diffs with `--diff`.
 - `foresthouse deps <directory>`: reads `package.json` manifests and workspace structure from a package directory and prints a package dependency tree. Use `--diff` to show only changes relative to a Git ref or range.
 
 ### Example
@@ -107,6 +108,7 @@ Usage:
   $ foresthouse react [entry-file] [options]
 
 Options:
+  --diff <git-ref-or-range>  Show only React tree changes relative to a Git revision or range.
   --cwd <path>     Working directory used for relative paths.
   --config <path>  Explicit tsconfig.json or jsconfig.json path.
   --nextjs         Infer Next.js page entries from app/ and pages/ when no entry is provided.
@@ -137,6 +139,7 @@ Common examples:
 - `foresthouse import src/main.ts`
 - `foresthouse import --entry src/main.ts --cwd test/fixtures/basic`
 - `foresthouse react src/App.tsx`
+- `foresthouse react src/App.tsx --diff origin/dev...HEAD`
 - `foresthouse react --nextjs --cwd .`
 - `foresthouse deps .`
 - `foresthouse deps ./packages/a`

--- a/bench/helpers.ts
+++ b/bench/helpers.ts
@@ -1,0 +1,79 @@
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const temporaryDirectories: string[] = []
+
+let cleanupRegistered = false
+const GIT_EXEC_MAX_BUFFER = 64 * 1024 * 1024
+
+export function createGitRepository(
+  prefix: string,
+  commits: readonly {
+    readonly message: string
+    readonly files: Readonly<Record<string, string>>
+  }[],
+): string {
+  registerCleanup()
+
+  const repositoryRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+  temporaryDirectories.push(repositoryRoot)
+
+  runGit(repositoryRoot, ['init', '--initial-branch=main'])
+  runGit(repositoryRoot, ['config', 'user.name', 'Foresthouse Benchmarks'])
+  runGit(repositoryRoot, ['config', 'user.email', 'benchmarks@example.com'])
+
+  commits.forEach((commit) => {
+    replaceRepositoryFiles(repositoryRoot, commit.files)
+    runGit(repositoryRoot, ['add', '-A'])
+    runGit(repositoryRoot, ['commit', '-m', commit.message])
+  })
+
+  return repositoryRoot
+}
+
+function replaceRepositoryFiles(
+  repositoryRoot: string,
+  files: Readonly<Record<string, string>>,
+): void {
+  fs.readdirSync(repositoryRoot, { withFileTypes: true }).forEach((entry) => {
+    if (entry.name === '.git') {
+      return
+    }
+
+    fs.rmSync(path.join(repositoryRoot, entry.name), {
+      recursive: true,
+      force: true,
+    })
+  })
+
+  Object.entries(files).forEach(([relativePath, fileContent]) => {
+    const absolutePath = path.join(repositoryRoot, relativePath)
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true })
+    fs.writeFileSync(absolutePath, fileContent)
+  })
+}
+
+function runGit(repositoryRoot: string, args: readonly string[]): string {
+  return execFileSync('git', args, {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+    maxBuffer: GIT_EXEC_MAX_BUFFER,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+}
+
+function registerCleanup(): void {
+  if (cleanupRegistered) {
+    return
+  }
+
+  cleanupRegistered = true
+
+  process.on('exit', () => {
+    temporaryDirectories.splice(0).forEach((directory) => {
+      fs.rmSync(directory, { recursive: true, force: true })
+    })
+  })
+}

--- a/e2e/deps.test.ts
+++ b/e2e/deps.test.ts
@@ -44,6 +44,7 @@ const pnpmMonorepoFixtureDirectory = path.join(
   'deps-pnpm-monorepo',
 )
 const temporaryDirectories: string[] = []
+const GIT_EXEC_MAX_BUFFER = 64 * 1024 * 1024
 
 afterEach(() => {
   temporaryDirectories.splice(0).forEach((directory) => {
@@ -1078,6 +1079,7 @@ function runGit(repositoryRoot: string, args: readonly string[]): string {
   return execFileSync('git', args, {
     cwd: repositoryRoot,
     encoding: 'utf8',
+    maxBuffer: GIT_EXEC_MAX_BUFFER,
     stdio: ['ignore', 'pipe', 'pipe'],
   }).trim()
 }

--- a/e2e/react.test.ts
+++ b/e2e/react.test.ts
@@ -1,7 +1,10 @@
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { main } from '../src/app/cli.js'
 import {
@@ -11,7 +14,10 @@ import {
 import { runCli } from '../src/app/run.js'
 import {
   analyzeReactUsage,
+  analyzeReactUsageDiff,
+  diffGraphToSerializableReactTree,
   graphToSerializableReactTree,
+  printReactUsageDiffTree,
   printReactUsageTree,
 } from '../src/index.js'
 
@@ -43,6 +49,14 @@ const nextjsFixtureDirectory = path.join(
   'fixtures',
   'nextjs-mode',
 )
+const temporaryDirectories: string[] = []
+const GIT_EXEC_MAX_BUFFER = 64 * 1024 * 1024
+
+afterEach(() => {
+  temporaryDirectories.splice(0).forEach((directory) => {
+    fs.rmSync(directory, { recursive: true, force: true })
+  })
+})
 
 beforeEach(() => {
   vi.mocked(runCli).mockReset()
@@ -61,6 +75,8 @@ describe('react command options', () => {
       '--project-only',
       '--json',
       '--builtin',
+      '--diff',
+      'HEAD~1',
       '--filter',
       'hook',
     ])
@@ -68,6 +84,7 @@ describe('react command options', () => {
     expect(runCli).toHaveBeenCalledWith({
       command: 'react',
       entryFile: 'src/main.tsx',
+      diff: 'HEAD~1',
       cwd: 'test/fixtures/react-mode',
       configPath: 'tsconfig.json',
       expandWorkspaces: false,
@@ -85,6 +102,7 @@ describe('react command options', () => {
     expect(runCli).toHaveBeenCalledWith({
       command: 'react',
       entryFile: undefined,
+      diff: undefined,
       cwd: 'test/fixtures/nextjs-mode',
       configPath: undefined,
       expandWorkspaces: true,
@@ -102,6 +120,7 @@ describe('react command options', () => {
     expect(runCli).toHaveBeenCalledWith({
       command: 'react',
       entryFile: 'src/main.tsx',
+      diff: undefined,
       cwd: undefined,
       configPath: undefined,
       expandWorkspaces: true,
@@ -119,6 +138,7 @@ describe('react command options', () => {
     expect(runCli).toHaveBeenCalledWith({
       command: 'react',
       entryFile: 'pages/index.tsx',
+      diff: undefined,
       cwd: undefined,
       configPath: undefined,
       expandWorkspaces: true,
@@ -146,6 +166,7 @@ describe('react entry discovery', () => {
       resolveReactEntryFiles({
         command: 'react',
         entryFile: 'pages/index.tsx',
+        diff: undefined,
         cwd: nextjsFixtureDirectory,
         configPath: undefined,
         expandWorkspaces: true,
@@ -781,3 +802,211 @@ describe('analyzeReactUsage', () => {
     })
   })
 })
+
+describe('analyzeReactUsageDiff', () => {
+  it('prints React tree changes for a Git range', () => {
+    const repositoryRoot = createGitRepository([
+      {
+        message: 'initial',
+        files: {
+          'package.json': JSON.stringify(
+            {
+              name: 'react-diff-fixture',
+              private: true,
+            },
+            null,
+            2,
+          ),
+          'tsconfig.json': JSON.stringify(
+            {
+              compilerOptions: {
+                jsx: 'react-jsx',
+              },
+            },
+            null,
+            2,
+          ),
+          'src/main.tsx': [
+            "import { AppShell } from './AppShell'",
+            '',
+            'void (<AppShell />)',
+            '',
+          ].join('\n'),
+          'src/AppShell.tsx': [
+            "import { Panel } from './components/Panel'",
+            '',
+            'export function AppShell() {',
+            '  return <Panel />',
+            '}',
+            '',
+          ].join('\n'),
+          'src/components/Panel.tsx': [
+            'export function Panel() {',
+            '  return <section />',
+            '}',
+            '',
+          ].join('\n'),
+        },
+      },
+      {
+        message: 'swap rendered component',
+        files: {
+          'package.json': JSON.stringify(
+            {
+              name: 'react-diff-fixture',
+              private: true,
+            },
+            null,
+            2,
+          ),
+          'tsconfig.json': JSON.stringify(
+            {
+              compilerOptions: {
+                jsx: 'react-jsx',
+              },
+            },
+            null,
+            2,
+          ),
+          'src/main.tsx': [
+            "import { AppShell } from './AppShell'",
+            '',
+            'void (<AppShell />)',
+            '',
+          ].join('\n'),
+          'src/AppShell.tsx': [
+            "import { Button } from './components/Button'",
+            '',
+            'export function AppShell() {',
+            '  return <Button />',
+            '}',
+            '',
+          ].join('\n'),
+          'src/components/Button.tsx': [
+            'export function Button() {',
+            '  return <button />',
+            '}',
+            '',
+          ].join('\n'),
+        },
+      },
+    ])
+
+    const graph = analyzeReactUsageDiff({
+      command: 'react',
+      entryFile: 'src/main.tsx',
+      diff: 'HEAD~1..HEAD',
+      cwd: repositoryRoot,
+      configPath: undefined,
+      expandWorkspaces: true,
+      projectOnly: false,
+      json: false,
+      filter: 'component',
+      nextjs: false,
+      includeBuiltins: false,
+    })
+    const output = printReactUsageDiffTree(graph, {
+      color: false,
+    })
+    const jsonTree = diffGraphToSerializableReactTree(graph)
+
+    expect(output).toBe(
+      [
+        '~ src/main.tsx:3:7',
+        '~ <AppShell /> [component] (src/AppShell.tsx)',
+        '├─ + <Button /> [component] (src/components/Button.tsx)',
+        '└─ - <Panel /> [component] (src/components/Panel.tsx)',
+      ].join('\n'),
+    )
+    expect(jsonTree).toMatchObject({
+      kind: 'react-usage-diff',
+      entries: [
+        expect.objectContaining({
+          change: 'unchanged',
+          afterFilePath: 'src/main.tsx',
+          afterLine: 3,
+          afterColumn: 7,
+          node: expect.objectContaining({
+            name: 'AppShell',
+            change: 'changed',
+            usages: expect.arrayContaining([
+              expect.objectContaining({
+                change: 'added',
+                referenceName: 'Button',
+                node: expect.objectContaining({
+                  name: 'Button',
+                  change: 'added',
+                }),
+              }),
+              expect.objectContaining({
+                change: 'removed',
+                referenceName: 'Panel',
+                node: expect.objectContaining({
+                  name: 'Panel',
+                  change: 'removed',
+                }),
+              }),
+            ]),
+          }),
+        }),
+      ],
+    })
+  })
+})
+
+function createGitRepository(
+  commits: readonly {
+    readonly message: string
+    readonly files: Readonly<Record<string, string>>
+  }[],
+): string {
+  const repositoryRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'foresthouse-react-git-fixture-'),
+  )
+
+  temporaryDirectories.push(repositoryRoot)
+
+  runGit(repositoryRoot, ['init', '--initial-branch=main'])
+  runGit(repositoryRoot, ['config', 'user.name', 'Foresthouse Tests'])
+  runGit(repositoryRoot, ['config', 'user.email', 'tests@example.com'])
+
+  commits.forEach((commit) => {
+    replaceRepositoryFiles(repositoryRoot, commit.files)
+    runGit(repositoryRoot, ['add', '-A'])
+    runGit(repositoryRoot, ['commit', '-m', commit.message])
+  })
+
+  return repositoryRoot
+}
+
+function replaceRepositoryFiles(
+  repositoryRoot: string,
+  files: Readonly<Record<string, string>>,
+): void {
+  fs.readdirSync(repositoryRoot, { withFileTypes: true }).forEach((entry) => {
+    if (entry.name === '.git') {
+      return
+    }
+
+    fs.rmSync(path.join(repositoryRoot, entry.name), {
+      recursive: true,
+      force: true,
+    })
+  })
+
+  Object.entries(files).forEach(([relativePath, fileContent]) => {
+    const absolutePath = path.join(repositoryRoot, relativePath)
+
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true })
+    fs.writeFileSync(absolutePath, fileContent)
+  })
+}
+
+function runGit(repositoryRoot: string, args: readonly string[]): string {
+  return execFileSync('git', args, {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+    maxBuffer: GIT_EXEC_MAX_BUFFER,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+}

--- a/src/analyzers/deps/diff.bench.ts
+++ b/src/analyzers/deps/diff.bench.ts
@@ -1,0 +1,133 @@
+import path from 'node:path'
+
+import { bench, describe } from 'vitest'
+
+import { createGitRepository } from '../../../bench/helpers.js'
+import { analyzePackageDependencyDiff } from './diff.js'
+
+const workspaceRepositoryRoot = createGitRepository(
+  'foresthouse-deps-diff-bench-',
+  [
+    {
+      message: 'initial',
+      files: {
+        'package.json': JSON.stringify(
+          {
+            name: 'deps-diff-bench',
+            private: true,
+            workspaces: ['apps/*', 'packages/*'],
+          },
+          null,
+          2,
+        ),
+        'apps/web/package.json': JSON.stringify(
+          {
+            name: '@repo/web',
+            dependencies: {
+              '@repo/ui': 'workspace:*',
+            },
+          },
+          null,
+          2,
+        ),
+        'packages/ui/package.json': JSON.stringify(
+          {
+            name: '@repo/ui',
+            dependencies: {
+              clsx: '^2.1.1',
+            },
+          },
+          null,
+          2,
+        ),
+        'packages/ui/src/index.ts': 'export const button = "primary"\n',
+      },
+    },
+    {
+      message: 'update workspace source',
+      files: {
+        'package.json': JSON.stringify(
+          {
+            name: 'deps-diff-bench',
+            private: true,
+            workspaces: ['apps/*', 'packages/*'],
+          },
+          null,
+          2,
+        ),
+        'apps/web/package.json': JSON.stringify(
+          {
+            name: '@repo/web',
+            dependencies: {
+              '@repo/ui': 'workspace:*',
+            },
+          },
+          null,
+          2,
+        ),
+        'packages/ui/package.json': JSON.stringify(
+          {
+            name: '@repo/ui',
+            dependencies: {
+              clsx: '^2.1.1',
+            },
+          },
+          null,
+          2,
+        ),
+        'packages/ui/src/index.ts': 'export const button = "secondary"\n',
+      },
+    },
+  ],
+)
+
+const specifierRepositoryRoot = createGitRepository(
+  'foresthouse-deps-spec-bench-',
+  [
+    {
+      message: 'initial',
+      files: {
+        'package.json': JSON.stringify(
+          {
+            name: 'deps-diff-single',
+            dependencies: {
+              react: '^19.1.1',
+              zod: '^3.25.0',
+            },
+          },
+          null,
+          2,
+        ),
+      },
+    },
+    {
+      message: 'bump dependency',
+      files: {
+        'package.json': JSON.stringify(
+          {
+            name: 'deps-diff-single',
+            dependencies: {
+              react: '^19.2.0',
+              zod: '^3.25.0',
+            },
+          },
+          null,
+          2,
+        ),
+      },
+    },
+  ],
+)
+
+describe('analyzePackageDependencyDiff', () => {
+  bench('workspace source change', () => {
+    analyzePackageDependencyDiff(
+      path.join(workspaceRepositoryRoot, 'apps', 'web'),
+      'HEAD~1..HEAD',
+    )
+  })
+
+  bench('manifest specifier change', () => {
+    analyzePackageDependencyDiff(specifierRepositoryRoot, 'HEAD~1..HEAD')
+  })
+})

--- a/src/analyzers/deps/diff.ts
+++ b/src/analyzers/deps/diff.ts
@@ -57,6 +57,7 @@ type ComparablePackageDependency =
 
 const PNPM_LOCKFILE = 'pnpm-lock.yaml'
 const PNPM_WORKSPACE_FILE = 'pnpm-workspace.yaml'
+const GIT_EXEC_MAX_BUFFER = 64 * 1024 * 1024
 
 export function analyzePackageDependencyDiff(
   directory: string,
@@ -928,6 +929,7 @@ function runGit(
 ): string {
   const output = execFileSync('git', ['-C', repositoryRoot, ...args], {
     encoding: 'utf8',
+    maxBuffer: GIT_EXEC_MAX_BUFFER,
     stdio: ['ignore', 'pipe', 'pipe'],
   })
 

--- a/src/analyzers/import/graph.bench.ts
+++ b/src/analyzers/import/graph.bench.ts
@@ -1,0 +1,54 @@
+import path from 'node:path'
+
+import { bench, describe } from 'vitest'
+
+import { loadCompilerOptions } from '../../typescript/config.js'
+import { resolveExistingPath } from './entry.js'
+import { buildDependencyGraph, type EntryConfig } from './graph.js'
+
+const fixturesDir = path.resolve(import.meta.dirname, '../../../test/fixtures')
+const basicCwd = path.join(fixturesDir, 'basic')
+const monorepoCwd = path.join(fixturesDir, 'monorepo', 'packages', 'app')
+
+const basicEntryConfig = createEntryConfig(basicCwd, 'src/main.ts')
+const monorepoEntryConfig = createEntryConfig(monorepoCwd, 'src/main.tsx')
+
+describe('buildDependencyGraph', () => {
+  bench('basic fixture', () => {
+    buildDependencyGraph([basicEntryConfig], {
+      cwd: basicCwd,
+      expandWorkspaces: true,
+      projectOnly: false,
+      trackUnusedImports: true,
+    })
+  })
+
+  bench('basic fixture without unused-import tracking', () => {
+    buildDependencyGraph([basicEntryConfig], {
+      cwd: basicCwd,
+      expandWorkspaces: true,
+      projectOnly: false,
+      trackUnusedImports: false,
+    })
+  })
+
+  bench('monorepo fixture', () => {
+    buildDependencyGraph([monorepoEntryConfig], {
+      cwd: monorepoCwd,
+      expandWorkspaces: true,
+      projectOnly: false,
+      trackUnusedImports: true,
+    })
+  })
+})
+
+function createEntryConfig(cwd: string, entryFile: string): EntryConfig {
+  const entryPath = resolveExistingPath(cwd, entryFile)
+  const loaded = loadCompilerOptions(path.dirname(entryPath))
+
+  return {
+    entryPath,
+    compilerOptions: loaded.compilerOptions,
+    ...(loaded.path === undefined ? {} : { configPath: loaded.path }),
+  }
+}

--- a/src/analyzers/react/diff.bench.ts
+++ b/src/analyzers/react/diff.bench.ts
@@ -1,0 +1,137 @@
+import { bench, describe } from 'vitest'
+
+import { createGitRepository } from '../../../bench/helpers.js'
+import type { ReactCliOptions } from '../../app/args.js'
+import { analyzeReactUsageDiff } from './diff.js'
+
+const repositoryRoot = createGitRepository('foresthouse-react-diff-bench-', [
+  {
+    message: 'initial',
+    files: {
+      'package.json': JSON.stringify(
+        {
+          name: 'react-diff-bench',
+          private: true,
+        },
+        null,
+        2,
+      ),
+      'tsconfig.json': JSON.stringify(
+        {
+          compilerOptions: {
+            jsx: 'react-jsx',
+          },
+        },
+        null,
+        2,
+      ),
+      'src/main.tsx': [
+        "import { AppShell } from './AppShell'",
+        '',
+        'void (<AppShell />)',
+        '',
+      ].join('\n'),
+      'src/AppShell.tsx': [
+        "import { Panel } from './components/Panel'",
+        "import { useFeature } from './hooks/useFeature'",
+        '',
+        'export function AppShell() {',
+        '  useFeature()',
+        '  return <Panel />',
+        '}',
+        '',
+      ].join('\n'),
+      'src/components/Panel.tsx': [
+        'export function Panel() {',
+        '  return <section />',
+        '}',
+        '',
+      ].join('\n'),
+      'src/hooks/useFeature.ts': [
+        'export function useFeature() {',
+        '  return true',
+        '}',
+        '',
+      ].join('\n'),
+    },
+  },
+  {
+    message: 'swap component and hook',
+    files: {
+      'package.json': JSON.stringify(
+        {
+          name: 'react-diff-bench',
+          private: true,
+        },
+        null,
+        2,
+      ),
+      'tsconfig.json': JSON.stringify(
+        {
+          compilerOptions: {
+            jsx: 'react-jsx',
+          },
+        },
+        null,
+        2,
+      ),
+      'src/main.tsx': [
+        "import { AppShell } from './AppShell'",
+        '',
+        'void (<AppShell />)',
+        '',
+      ].join('\n'),
+      'src/AppShell.tsx': [
+        "import { Button } from './components/Button'",
+        "import { usePanelState } from './hooks/usePanelState'",
+        '',
+        'export function AppShell() {',
+        '  usePanelState()',
+        '  return <Button />',
+        '}',
+        '',
+      ].join('\n'),
+      'src/components/Button.tsx': [
+        'export function Button() {',
+        '  return <button />',
+        '}',
+        '',
+      ].join('\n'),
+      'src/hooks/usePanelState.ts': [
+        'export function usePanelState() {',
+        '  return { open: true }',
+        '}',
+        '',
+      ].join('\n'),
+    },
+  },
+])
+
+const componentDiffOptions: ReactCliOptions = {
+  command: 'react',
+  entryFile: 'src/main.tsx',
+  diff: 'HEAD~1..HEAD',
+  cwd: repositoryRoot,
+  configPath: undefined,
+  expandWorkspaces: true,
+  projectOnly: false,
+  json: false,
+  filter: 'component',
+  nextjs: false,
+  includeBuiltins: false,
+}
+
+const allDiffOptions: ReactCliOptions = {
+  ...componentDiffOptions,
+  filter: 'all',
+}
+
+describe('analyzeReactUsageDiff', () => {
+  bench('component-only diff', () => {
+    analyzeReactUsageDiff(componentDiffOptions)
+  })
+
+  bench('full component and hook diff', () => {
+    analyzeReactUsageDiff(allDiffOptions)
+  })
+})

--- a/src/analyzers/react/diff.ts
+++ b/src/analyzers/react/diff.ts
@@ -1,0 +1,1070 @@
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import type { ReactCliOptions } from '../../app/args.js'
+import { resolveReactEntryFiles } from '../../app/react-entry-files.js'
+import type { AnalyzeOptions } from '../../types/analyze-options.js'
+import type { PackageDependencyChangeKind } from '../../types/package-dependency-change-kind.js'
+import type { ReactSymbolKind } from '../../types/react-symbol-kind.js'
+import type { ReactUsageDiffEdge } from '../../types/react-usage-diff-edge.js'
+import type { ReactUsageDiffEntry } from '../../types/react-usage-diff-entry.js'
+import type { ReactUsageDiffGraph } from '../../types/react-usage-diff-graph.js'
+import type { ReactUsageDiffNode } from '../../types/react-usage-diff-node.js'
+import type { ReactUsageEdge } from '../../types/react-usage-edge.js'
+import type { ReactUsageEntry } from '../../types/react-usage-entry.js'
+import type { ReactUsageFilter } from '../../types/react-usage-filter.js'
+import type { ReactUsageGraph } from '../../types/react-usage-graph.js'
+import type { ReactUsageNode } from '../../types/react-usage-node.js'
+import { toDisplayPath } from '../../utils/to-display-path.js'
+import { analyzeReactUsage } from './index.js'
+import {
+  getFilteredUsages,
+  getReactUsageEntries,
+  getReactUsageRoots,
+} from './queries.js'
+
+interface GitDiffComparison {
+  readonly beforeTree: string
+  readonly afterTree: string | undefined
+}
+
+interface ReactDiffAnalysisContext {
+  readonly repositoryRoot: string
+  readonly originalCwd: string
+  readonly cwdWithinRepository: string
+  readonly entryFile: string | undefined
+  readonly nextjs: boolean
+  readonly filter: ReactUsageFilter
+  readonly includeBuiltins: boolean
+  readonly analyzeOptions: AnalyzeOptions
+}
+
+interface ComparableReactGraph {
+  readonly entriesByKey: ReadonlyMap<string, ComparableReactEntry>
+  readonly rootIds: readonly string[]
+  readonly nodes: ReadonlyMap<string, ComparableReactNode>
+}
+
+interface ComparableReactNode {
+  readonly id: string
+  readonly name: string
+  readonly symbolKind: ReactSymbolKind
+  readonly filePath: string
+  readonly exportNames: readonly string[]
+  readonly usagesByKey: ReadonlyMap<string, ComparableReactEdge>
+}
+
+interface ComparableReactEdge {
+  readonly key: string
+  readonly kind: ReactUsageEdge['kind']
+  readonly targetId: string
+  readonly referenceName: string
+}
+
+interface ComparableReactEntry {
+  readonly key: string
+  readonly targetId: string
+  readonly referenceName: string
+  readonly filePath: string
+  readonly line: number
+  readonly column: number
+}
+
+export function analyzeReactUsageDiff(
+  options: ReactCliOptions,
+): ReactUsageDiffGraph {
+  const originalCwd = resolveOriginalCwd(options.cwd)
+  const repositoryRoot = findGitRepositoryRoot(
+    resolveDiffInputPath(options, originalCwd),
+  )
+  const comparison = resolveGitDiffComparison(
+    repositoryRoot,
+    options.diff ?? 'HEAD',
+  )
+  const context: ReactDiffAnalysisContext = {
+    repositoryRoot,
+    originalCwd,
+    cwdWithinRepository: resolvePathWithinRepository(
+      originalCwd,
+      repositoryRoot,
+      'Working directory',
+    ),
+    entryFile: options.entryFile,
+    nextjs: options.nextjs,
+    filter: options.filter,
+    includeBuiltins: options.includeBuiltins,
+    analyzeOptions: toAnalyzeOptions(options),
+  }
+  const beforeGraph = loadGitTreeGraph(context, comparison.beforeTree)
+  const afterGraph =
+    comparison.afterTree === undefined
+      ? loadWorkingTreeGraph(context)
+      : loadGitTreeGraph(context, comparison.afterTree)
+
+  if (beforeGraph === undefined && afterGraph === undefined) {
+    throw new Error(
+      'No React entry files found for the requested diff. Check the entry path or Next.js discovery roots.',
+    )
+  }
+
+  const entries = diffEntries(beforeGraph, afterGraph)
+  const roots =
+    entries.length > 0
+      ? entries.map((entry) => entry.node)
+      : diffRoots(beforeGraph, afterGraph)
+
+  return {
+    kind: 'react-usage-diff',
+    repositoryRoot,
+    cwd: originalCwd,
+    entries,
+    roots,
+  }
+}
+
+const GIT_EXEC_MAX_BUFFER = 64 * 1024 * 1024
+
+function resolveOriginalCwd(cwd: string | undefined): string {
+  return path.resolve(cwd ?? process.cwd())
+}
+
+function resolveDiffInputPath(
+  options: ReactCliOptions,
+  originalCwd: string,
+): string {
+  if (options.entryFile === undefined) {
+    return originalCwd
+  }
+
+  return path.isAbsolute(options.entryFile)
+    ? path.resolve(options.entryFile)
+    : path.resolve(originalCwd, options.entryFile)
+}
+
+function toAnalyzeOptions(options: ReactCliOptions): AnalyzeOptions {
+  return {
+    ...(options.configPath === undefined
+      ? {}
+      : { configPath: options.configPath }),
+    expandWorkspaces: options.expandWorkspaces,
+    projectOnly: options.projectOnly,
+    includeBuiltins: options.includeBuiltins,
+  }
+}
+
+function loadWorkingTreeGraph(
+  context: ReactDiffAnalysisContext,
+): ComparableReactGraph | undefined {
+  return tryAnalyzeComparableReactGraph(context, context.repositoryRoot)
+}
+
+function loadGitTreeGraph(
+  context: ReactDiffAnalysisContext,
+  tree: string,
+): ComparableReactGraph | undefined {
+  const snapshotRoot = materializeGitTreeSnapshot(context.repositoryRoot, tree)
+
+  try {
+    return tryAnalyzeComparableReactGraph(context, snapshotRoot)
+  } finally {
+    fs.rmSync(snapshotRoot, { recursive: true, force: true })
+  }
+}
+
+function tryAnalyzeComparableReactGraph(
+  context: ReactDiffAnalysisContext,
+  workingRoot: string,
+): ComparableReactGraph | undefined {
+  const snapshotCwd = resolveSnapshotCwd(
+    workingRoot,
+    context.cwdWithinRepository,
+  )
+  const entryFiles = resolveSnapshotEntryFiles(
+    context,
+    snapshotCwd,
+    workingRoot,
+  )
+
+  if (entryFiles === undefined || entryFiles.length === 0) {
+    return undefined
+  }
+
+  const graph = analyzeReactUsage(entryFiles, {
+    ...context.analyzeOptions,
+    cwd: snapshotCwd,
+    ...(context.analyzeOptions.configPath === undefined
+      ? {}
+      : {
+          configPath: resolveSnapshotConfigPath(
+            context.analyzeOptions.configPath,
+            workingRoot,
+            context.repositoryRoot,
+          ),
+        }),
+  })
+
+  return toComparableGraph(
+    graph,
+    context.repositoryRoot,
+    context.originalCwd,
+    context.filter,
+  )
+}
+
+function resolveSnapshotCwd(
+  workingRoot: string,
+  cwdWithinRepository: string,
+): string {
+  return cwdWithinRepository.length === 0
+    ? workingRoot
+    : path.join(workingRoot, cwdWithinRepository)
+}
+
+function resolveSnapshotEntryFiles(
+  context: ReactDiffAnalysisContext,
+  snapshotCwd: string,
+  workingRoot: string,
+): string[] | undefined {
+  if (context.entryFile !== undefined) {
+    const entryFile = resolveSnapshotEntryPath(
+      context.entryFile,
+      workingRoot,
+      context.repositoryRoot,
+    )
+
+    return doesResolvedPathExist(entryFile, snapshotCwd)
+      ? [entryFile]
+      : undefined
+  }
+
+  if (!context.nextjs) {
+    throw new Error(
+      'Missing React entry file. Use `foresthouse react <entry-file>` or `foresthouse react --nextjs`.',
+    )
+  }
+
+  try {
+    return resolveReactEntryFiles({
+      command: 'react',
+      entryFile: undefined,
+      diff: undefined,
+      cwd: snapshotCwd,
+      configPath: undefined,
+      expandWorkspaces: true,
+      projectOnly: false,
+      json: false,
+      filter: context.filter,
+      nextjs: true,
+      includeBuiltins: context.includeBuiltins,
+    })
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.startsWith('No Next.js page entries found.')
+    ) {
+      return undefined
+    }
+
+    throw error
+  }
+}
+
+function resolveSnapshotEntryPath(
+  entryFile: string,
+  workingRoot: string,
+  repositoryRoot: string,
+): string {
+  if (!path.isAbsolute(entryFile)) {
+    return entryFile
+  }
+
+  const entryWithinRepository = resolvePathWithinRepository(
+    entryFile,
+    repositoryRoot,
+    'React entry file',
+  )
+
+  return entryWithinRepository.length === 0
+    ? workingRoot
+    : path.join(workingRoot, entryWithinRepository)
+}
+
+function resolveSnapshotConfigPath(
+  configPath: string,
+  workingRoot: string,
+  repositoryRoot: string,
+): string {
+  if (!path.isAbsolute(configPath)) {
+    return configPath
+  }
+
+  const configWithinRepository = resolvePathWithinRepository(
+    configPath,
+    repositoryRoot,
+    'TypeScript config',
+  )
+
+  return configWithinRepository.length === 0
+    ? workingRoot
+    : path.join(workingRoot, configWithinRepository)
+}
+
+function doesResolvedPathExist(entryFile: string, cwd: string): boolean {
+  const resolvedEntryPath = path.isAbsolute(entryFile)
+    ? entryFile
+    : path.resolve(cwd, entryFile)
+
+  return fs.existsSync(resolvedEntryPath)
+}
+
+function toComparableGraph(
+  graph: ReactUsageGraph,
+  _repositoryRoot: string,
+  originalCwd: string,
+  filter: ReactUsageFilter,
+): ComparableReactGraph {
+  const nodes = new Map<string, ComparableReactNode>()
+
+  graph.nodes.forEach((node) => {
+    const comparableNode = toComparableNode(node, graph, originalCwd, filter)
+    nodes.set(comparableNode.id, comparableNode)
+  })
+
+  const entries = indexEntries(
+    getReactUsageEntries(graph, filter).map((entry) =>
+      toComparableEntry(entry, graph, originalCwd),
+    ),
+  )
+
+  return {
+    entriesByKey: new Map(entries.map((entry) => [entry.key, entry])),
+    rootIds: getReactUsageRoots(graph, filter)
+      .map((rootId) => {
+        const node = graph.nodes.get(rootId)
+        return node === undefined
+          ? undefined
+          : createComparableNodeId(node, graph.cwd)
+      })
+      .filter((rootId): rootId is string => rootId !== undefined),
+    nodes,
+  }
+}
+
+function toComparableNode(
+  node: ReactUsageNode,
+  graph: ReactUsageGraph,
+  originalCwd: string,
+  filter: ReactUsageFilter,
+): ComparableReactNode {
+  const usages = indexUsages(
+    getFilteredUsages(node, graph, filter).map((usage) =>
+      toComparableEdge(usage, graph),
+    ),
+  )
+
+  return {
+    id: createComparableNodeId(node, graph.cwd),
+    name: node.name,
+    symbolKind: node.kind,
+    filePath: toDisplayFilePath(node.filePath, graph.cwd, originalCwd),
+    exportNames: [...node.exportNames].sort(),
+    usagesByKey: new Map(usages.map((usage) => [usage.key, usage])),
+  }
+}
+
+function toComparableEdge(
+  usage: ReactUsageEdge,
+  graph: ReactUsageGraph,
+): Omit<ComparableReactEdge, 'key'> {
+  const targetNode = graph.nodes.get(usage.target)
+
+  return {
+    kind: usage.kind,
+    targetId:
+      targetNode === undefined
+        ? usage.target
+        : createComparableNodeId(targetNode, graph.cwd),
+    referenceName: usage.referenceName,
+  }
+}
+
+function toComparableEntry(
+  entry: ReactUsageEntry,
+  graph: ReactUsageGraph,
+  originalCwd: string,
+): Omit<ComparableReactEntry, 'key'> {
+  const targetNode = graph.nodes.get(entry.target)
+
+  return {
+    targetId:
+      targetNode === undefined
+        ? entry.target
+        : createComparableNodeId(targetNode, graph.cwd),
+    referenceName: entry.referenceName,
+    filePath: toDisplayFilePath(
+      entry.location.filePath,
+      graph.cwd,
+      originalCwd,
+    ),
+    line: entry.location.line,
+    column: entry.location.column,
+  }
+}
+
+function indexUsages(
+  usages: readonly Omit<ComparableReactEdge, 'key'>[],
+): ComparableReactEdge[] {
+  const counts = new Map<string, number>()
+
+  return [...usages].sort(compareComparableEdgeState).map((usage) => {
+    const signature = `${usage.kind}:${usage.targetId}`
+    const occurrence = counts.get(signature) ?? 0
+    counts.set(signature, occurrence + 1)
+
+    return {
+      ...usage,
+      key: `${signature}#${occurrence}`,
+    }
+  })
+}
+
+function indexEntries(
+  entries: readonly Omit<ComparableReactEntry, 'key'>[],
+): ComparableReactEntry[] {
+  const counts = new Map<string, number>()
+
+  return [...entries].sort(compareComparableEntryState).map((entry) => {
+    const signature = `${entry.filePath}:${entry.targetId}`
+    const occurrence = counts.get(signature) ?? 0
+    counts.set(signature, occurrence + 1)
+
+    return {
+      ...entry,
+      key: `${signature}#${occurrence}`,
+    }
+  })
+}
+
+function createComparableNodeId(
+  node: ReactUsageNode,
+  analysisCwd: string,
+): string {
+  return `${node.kind}:${toComparablePath(node.filePath, analysisCwd)}#${node.name}`
+}
+
+function toComparablePath(filePath: string, analysisCwd: string): string {
+  if (!path.isAbsolute(filePath)) {
+    return normalizePathSeparators(filePath)
+  }
+
+  const relativePath = path.relative(
+    fs.realpathSync.native(analysisCwd),
+    fs.realpathSync.native(filePath),
+  )
+  if (relativePath === '') {
+    return '.'
+  }
+
+  return normalizePathSeparators(relativePath)
+}
+
+function toDisplayFilePath(
+  filePath: string,
+  analysisCwd: string,
+  originalCwd: string,
+): string {
+  if (!path.isAbsolute(filePath)) {
+    return normalizePathSeparators(filePath)
+  }
+
+  const relativePath = path.relative(
+    fs.realpathSync.native(analysisCwd),
+    fs.realpathSync.native(filePath),
+  )
+  if (relativePath === '') {
+    return '.'
+  }
+
+  return toDisplayPath(path.resolve(originalCwd, relativePath), originalCwd)
+}
+
+function diffEntries(
+  beforeGraph: ComparableReactGraph | undefined,
+  afterGraph: ComparableReactGraph | undefined,
+): ReactUsageDiffEntry[] {
+  const entryKeys = new Set<string>([
+    ...Array.from(beforeGraph?.entriesByKey.keys() ?? []),
+    ...Array.from(afterGraph?.entriesByKey.keys() ?? []),
+  ])
+
+  return Array.from(entryKeys)
+    .sort((left, right) =>
+      compareComparableEntryState(
+        beforeGraph?.entriesByKey.get(left) ??
+          afterGraph?.entriesByKey.get(left),
+        beforeGraph?.entriesByKey.get(right) ??
+          afterGraph?.entriesByKey.get(right),
+      ),
+    )
+    .flatMap((entryKey) => {
+      const beforeEntry = beforeGraph?.entriesByKey.get(entryKey)
+      const afterEntry = afterGraph?.entriesByKey.get(entryKey)
+      const node = diffNode(
+        beforeEntry?.targetId,
+        afterEntry?.targetId,
+        beforeGraph,
+        afterGraph,
+        new Set<string>(),
+      )
+      const change = resolveEntryChange(beforeEntry, afterEntry)
+
+      if (change === 'unchanged' && !hasVisibleNodeChanges(node)) {
+        return []
+      }
+
+      const currentEntry = afterEntry ?? beforeEntry
+      if (currentEntry === undefined) {
+        return []
+      }
+
+      return [
+        {
+          key: currentEntry.key,
+          change,
+          targetId: node.id,
+          referenceName:
+            afterEntry?.referenceName ??
+            beforeEntry?.referenceName ??
+            node.name,
+          ...(beforeEntry === undefined
+            ? {}
+            : {
+                beforeReferenceName: beforeEntry.referenceName,
+                beforeFilePath: beforeEntry.filePath,
+                beforeLine: beforeEntry.line,
+                beforeColumn: beforeEntry.column,
+              }),
+          ...(afterEntry === undefined
+            ? {}
+            : {
+                afterReferenceName: afterEntry.referenceName,
+                afterFilePath: afterEntry.filePath,
+                afterLine: afterEntry.line,
+                afterColumn: afterEntry.column,
+              }),
+          node,
+        },
+      ]
+    })
+}
+
+function diffRoots(
+  beforeGraph: ComparableReactGraph | undefined,
+  afterGraph: ComparableReactGraph | undefined,
+): ReactUsageDiffNode[] {
+  const rootIds = new Set<string>([
+    ...Array.from(beforeGraph?.rootIds ?? []),
+    ...Array.from(afterGraph?.rootIds ?? []),
+  ])
+
+  return Array.from(rootIds)
+    .sort((left, right) =>
+      compareComparableNodeState(
+        beforeGraph?.nodes.get(left) ?? afterGraph?.nodes.get(left),
+        beforeGraph?.nodes.get(right) ?? afterGraph?.nodes.get(right),
+      ),
+    )
+    .flatMap((rootId) => {
+      const node = diffNode(
+        beforeGraph?.nodes.has(rootId) === true ? rootId : undefined,
+        afterGraph?.nodes.has(rootId) === true ? rootId : undefined,
+        beforeGraph,
+        afterGraph,
+        new Set<string>(),
+      )
+
+      return hasVisibleNodeChanges(node) ? [node] : []
+    })
+}
+
+function diffNode(
+  beforeNodeId: string | undefined,
+  afterNodeId: string | undefined,
+  beforeGraph: ComparableReactGraph | undefined,
+  afterGraph: ComparableReactGraph | undefined,
+  ancestry: ReadonlySet<string>,
+): ReactUsageDiffNode {
+  const beforeNode =
+    beforeNodeId === undefined
+      ? undefined
+      : beforeGraph?.nodes.get(beforeNodeId)
+  const afterNode =
+    afterNodeId === undefined ? undefined : afterGraph?.nodes.get(afterNodeId)
+
+  if (beforeNode === undefined && afterNode === undefined) {
+    throw new Error('Unable to resolve React diff node.')
+  }
+
+  const ancestryKey = `${beforeNodeId ?? ''}->${afterNodeId ?? ''}`
+  if (ancestry.has(ancestryKey)) {
+    const node = afterNode ?? beforeNode
+    if (node === undefined) {
+      throw new Error('Unable to resolve circular React diff node.')
+    }
+
+    return {
+      id: node.id,
+      name: node.name,
+      symbolKind: node.symbolKind,
+      circular: true,
+      filePath: node.filePath,
+      change: 'unchanged',
+      exportNames: node.exportNames,
+      usages: [],
+    }
+  }
+
+  const nextAncestry = new Set(ancestry)
+  nextAncestry.add(ancestryKey)
+
+  const usages = collectUsageDiffs(
+    beforeNode,
+    afterNode,
+    beforeGraph,
+    afterGraph,
+    nextAncestry,
+  )
+  const directChange = resolveNodeDirectChange(beforeNode, afterNode)
+  const node = afterNode ?? beforeNode
+
+  if (node === undefined) {
+    throw new Error('Unable to resolve React diff node.')
+  }
+
+  return {
+    id: node.id,
+    name: node.name,
+    symbolKind: node.symbolKind,
+    filePath: node.filePath,
+    change:
+      directChange === 'unchanged' && usages.length > 0
+        ? 'changed'
+        : directChange,
+    exportNames: node.exportNames,
+    ...(beforeNode === undefined
+      ? {}
+      : { beforeExportNames: beforeNode.exportNames }),
+    ...(afterNode === undefined
+      ? {}
+      : { afterExportNames: afterNode.exportNames }),
+    usages,
+  }
+}
+
+function collectUsageDiffs(
+  beforeNode: ComparableReactNode | undefined,
+  afterNode: ComparableReactNode | undefined,
+  beforeGraph: ComparableReactGraph | undefined,
+  afterGraph: ComparableReactGraph | undefined,
+  ancestry: ReadonlySet<string>,
+): ReactUsageDiffEdge[] {
+  const usageKeys = new Set<string>([
+    ...Array.from(beforeNode?.usagesByKey.keys() ?? []),
+    ...Array.from(afterNode?.usagesByKey.keys() ?? []),
+  ])
+
+  return Array.from(usageKeys)
+    .sort((left, right) =>
+      compareComparableEdgeState(
+        beforeNode?.usagesByKey.get(left) ?? afterNode?.usagesByKey.get(left),
+        beforeNode?.usagesByKey.get(right) ?? afterNode?.usagesByKey.get(right),
+      ),
+    )
+    .flatMap((usageKey) => {
+      const beforeUsage = beforeNode?.usagesByKey.get(usageKey)
+      const afterUsage = afterNode?.usagesByKey.get(usageKey)
+      const node = diffNode(
+        beforeUsage?.targetId,
+        afterUsage?.targetId,
+        beforeGraph,
+        afterGraph,
+        ancestry,
+      )
+      const change = resolveEdgeChange(beforeUsage, afterUsage)
+
+      if (change === 'unchanged' && !hasVisibleNodeChanges(node)) {
+        return []
+      }
+
+      return [
+        {
+          key: afterUsage?.key ?? beforeUsage?.key ?? usageKey,
+          kind: afterUsage?.kind ?? beforeUsage?.kind ?? 'render',
+          change,
+          targetId: node.id,
+          referenceName:
+            afterUsage?.referenceName ??
+            beforeUsage?.referenceName ??
+            node.name,
+          ...(beforeUsage === undefined
+            ? {}
+            : { beforeReferenceName: beforeUsage.referenceName }),
+          ...(afterUsage === undefined
+            ? {}
+            : { afterReferenceName: afterUsage.referenceName }),
+          node,
+        },
+      ]
+    })
+}
+
+function resolveEntryChange(
+  beforeEntry: ComparableReactEntry | undefined,
+  afterEntry: ComparableReactEntry | undefined,
+): PackageDependencyChangeKind {
+  if (beforeEntry === undefined && afterEntry !== undefined) {
+    return 'added'
+  }
+
+  if (beforeEntry !== undefined && afterEntry === undefined) {
+    return 'removed'
+  }
+
+  if (beforeEntry === undefined || afterEntry === undefined) {
+    return 'unchanged'
+  }
+
+  return beforeEntry.targetId === afterEntry.targetId &&
+    beforeEntry.referenceName === afterEntry.referenceName &&
+    beforeEntry.filePath === afterEntry.filePath &&
+    beforeEntry.line === afterEntry.line &&
+    beforeEntry.column === afterEntry.column
+    ? 'unchanged'
+    : 'changed'
+}
+
+function resolveNodeDirectChange(
+  beforeNode: ComparableReactNode | undefined,
+  afterNode: ComparableReactNode | undefined,
+): PackageDependencyChangeKind {
+  if (beforeNode === undefined && afterNode !== undefined) {
+    return 'added'
+  }
+
+  if (beforeNode !== undefined && afterNode === undefined) {
+    return 'removed'
+  }
+
+  if (beforeNode === undefined || afterNode === undefined) {
+    return 'unchanged'
+  }
+
+  return beforeNode.name === afterNode.name &&
+    beforeNode.symbolKind === afterNode.symbolKind &&
+    beforeNode.filePath === afterNode.filePath &&
+    areStringArraysEqual(beforeNode.exportNames, afterNode.exportNames)
+    ? 'unchanged'
+    : 'changed'
+}
+
+function resolveEdgeChange(
+  beforeUsage: ComparableReactEdge | undefined,
+  afterUsage: ComparableReactEdge | undefined,
+): PackageDependencyChangeKind {
+  if (beforeUsage === undefined && afterUsage !== undefined) {
+    return 'added'
+  }
+
+  if (beforeUsage !== undefined && afterUsage === undefined) {
+    return 'removed'
+  }
+
+  if (beforeUsage === undefined || afterUsage === undefined) {
+    return 'unchanged'
+  }
+
+  return beforeUsage.kind === afterUsage.kind &&
+    beforeUsage.targetId === afterUsage.targetId &&
+    beforeUsage.referenceName === afterUsage.referenceName
+    ? 'unchanged'
+    : 'changed'
+}
+
+function hasVisibleNodeChanges(node: ReactUsageDiffNode): boolean {
+  return node.change !== 'unchanged' || node.usages.length > 0
+}
+
+function compareComparableNodeState(
+  left: ComparableReactNode | undefined,
+  right: ComparableReactNode | undefined,
+): number {
+  return (
+    (left?.filePath ?? '').localeCompare(right?.filePath ?? '') ||
+    (left?.name ?? '').localeCompare(right?.name ?? '') ||
+    (left?.symbolKind ?? '').localeCompare(right?.symbolKind ?? '')
+  )
+}
+
+function compareComparableEdgeState(
+  left: Omit<ComparableReactEdge, 'key'> | ComparableReactEdge | undefined,
+  right: Omit<ComparableReactEdge, 'key'> | ComparableReactEdge | undefined,
+): number {
+  return (
+    (left?.targetId ?? '').localeCompare(right?.targetId ?? '') ||
+    (left?.referenceName ?? '').localeCompare(right?.referenceName ?? '') ||
+    (left?.kind ?? '').localeCompare(right?.kind ?? '')
+  )
+}
+
+function compareComparableEntryState(
+  left: Omit<ComparableReactEntry, 'key'> | ComparableReactEntry | undefined,
+  right: Omit<ComparableReactEntry, 'key'> | ComparableReactEntry | undefined,
+): number {
+  return (
+    (left?.filePath ?? '').localeCompare(right?.filePath ?? '') ||
+    (left?.line ?? 0) - (right?.line ?? 0) ||
+    (left?.column ?? 0) - (right?.column ?? 0) ||
+    (left?.referenceName ?? '').localeCompare(right?.referenceName ?? '') ||
+    (left?.targetId ?? '').localeCompare(right?.targetId ?? '')
+  )
+}
+
+function areStringArraysEqual(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  )
+}
+
+function resolvePathWithinRepository(
+  resolvedPath: string,
+  repositoryRoot: string,
+  label: string,
+): string {
+  const absolutePath = path.resolve(resolvedPath)
+  const existingPath = findNearestExistingPath(absolutePath)
+  const existingRealPath = fs.realpathSync.native(existingPath)
+  const repositoryRealPath = fs.realpathSync.native(repositoryRoot)
+  const relativeFromExistingPath = path.relative(existingPath, absolutePath)
+  const relativePath = path.normalize(
+    path.join(
+      path.relative(repositoryRealPath, existingRealPath),
+      relativeFromExistingPath,
+    ),
+  )
+
+  if (relativePath === '') {
+    return ''
+  }
+
+  if (relativePath.startsWith('..')) {
+    throw new Error(
+      `${label} must be inside the Git repository when using --diff.`,
+    )
+  }
+
+  return normalizePathSeparators(relativePath)
+}
+
+function findGitRepositoryRoot(resolvedInputPath: string): string {
+  const searchPath = findNearestExistingPath(resolvedInputPath)
+
+  try {
+    return runGit(searchPath, ['rev-parse', '--show-toplevel']).trim()
+  } catch (error) {
+    throw new Error(
+      `Git diff mode requires a Git repository: ${getCommandErrorMessage(error)}`,
+    )
+  }
+}
+
+function findNearestExistingPath(resolvedInputPath: string): string {
+  let currentPath = resolvedInputPath
+
+  while (!fs.existsSync(currentPath)) {
+    const parentPath = path.dirname(currentPath)
+
+    if (parentPath === currentPath) {
+      return resolvedInputPath
+    }
+
+    currentPath = parentPath
+  }
+
+  if (fs.statSync(currentPath).isFile()) {
+    return path.dirname(currentPath)
+  }
+
+  return currentPath
+}
+
+function resolveGitDiffComparison(
+  repositoryRoot: string,
+  diff: string,
+): GitDiffComparison {
+  if (diff.includes('...')) {
+    const [baseRef, headRef] = splitDiffRange(diff, '...')
+
+    try {
+      const mergeBase = runGit(repositoryRoot, [
+        'merge-base',
+        baseRef,
+        headRef,
+      ]).trim()
+
+      return {
+        beforeTree: resolveGitTree(repositoryRoot, mergeBase),
+        afterTree: resolveGitTree(repositoryRoot, headRef),
+      }
+    } catch (error) {
+      throw new Error(
+        `Failed to resolve Git diff spec \`${diff}\`: ${getCommandErrorMessage(error)}`,
+      )
+    }
+  }
+
+  if (diff.includes('..')) {
+    const [beforeRef, afterRef] = splitDiffRange(diff, '..')
+
+    try {
+      return {
+        beforeTree: resolveGitTree(repositoryRoot, beforeRef),
+        afterTree: resolveGitTree(repositoryRoot, afterRef),
+      }
+    } catch (error) {
+      throw new Error(
+        `Failed to resolve Git diff spec \`${diff}\`: ${getCommandErrorMessage(error)}`,
+      )
+    }
+  }
+
+  try {
+    return {
+      beforeTree: resolveGitTree(repositoryRoot, diff),
+      afterTree: undefined,
+    }
+  } catch (error) {
+    throw new Error(
+      `Failed to resolve Git diff spec \`${diff}\`: ${getCommandErrorMessage(error)}`,
+    )
+  }
+}
+
+function splitDiffRange(
+  diff: string,
+  separator: '...' | '..',
+): readonly [string, string] {
+  const [left, right, ...extra] = diff.split(separator)
+
+  if (
+    left === undefined ||
+    right === undefined ||
+    left.length === 0 ||
+    right.length === 0 ||
+    extra.length > 0
+  ) {
+    throw new Error(`Invalid Git diff spec \`${diff}\``)
+  }
+
+  return [left, right]
+}
+
+function resolveGitTree(repositoryRoot: string, reference: string): string {
+  return runGit(repositoryRoot, [
+    'rev-parse',
+    '--verify',
+    `${reference}^{tree}`,
+  ]).trim()
+}
+
+function materializeGitTreeSnapshot(
+  repositoryRoot: string,
+  tree: string,
+): string {
+  const snapshotRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'foresthouse-react-diff-'),
+  )
+  const trackedFiles = runGit(repositoryRoot, [
+    'ls-tree',
+    '-r',
+    '-z',
+    '--name-only',
+    tree,
+  ])
+    .split('\u0000')
+    .filter((filePath) => filePath.length > 0)
+
+  trackedFiles.forEach((filePath) => {
+    ensureSnapshotDirectory(snapshotRoot, filePath)
+  })
+
+  trackedFiles.forEach((filePath) => {
+    const fileContent = runGit(
+      repositoryRoot,
+      ['cat-file', '-p', `${tree}:${filePath}`],
+      {
+        trim: false,
+      },
+    )
+    const absolutePath = path.join(snapshotRoot, ...filePath.split('/'))
+
+    fs.writeFileSync(absolutePath, fileContent)
+  })
+
+  return snapshotRoot
+}
+
+function ensureSnapshotDirectory(snapshotRoot: string, filePath: string): void {
+  const parentDirectory = path.dirname(filePath)
+
+  if (parentDirectory === '.') {
+    return
+  }
+
+  fs.mkdirSync(path.join(snapshotRoot, ...parentDirectory.split('/')), {
+    recursive: true,
+  })
+}
+
+function runGit(
+  repositoryRoot: string,
+  args: readonly string[],
+  options: {
+    readonly trim?: boolean
+  } = {},
+): string {
+  const output = execFileSync('git', ['-C', repositoryRoot, ...args], {
+    encoding: 'utf8',
+    maxBuffer: GIT_EXEC_MAX_BUFFER,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  return options.trim === false ? output : output.trimEnd()
+}
+
+function getCommandErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return 'Unknown Git error'
+  }
+
+  const stderr = Reflect.get(error, 'stderr')
+
+  if (typeof stderr === 'string' && stderr.trim().length > 0) {
+    return stderr.trim()
+  }
+
+  if (Buffer.isBuffer(stderr) && stderr.byteLength > 0) {
+    return stderr.toString('utf8').trim()
+  }
+
+  return error.message
+}
+
+function normalizePathSeparators(filePath: string): string {
+  return filePath.split(path.sep).join('/')
+}

--- a/src/analyzers/react/file.bench.ts
+++ b/src/analyzers/react/file.bench.ts
@@ -1,0 +1,77 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { parseSync } from 'oxc-parser'
+import { bench, describe } from 'vitest'
+
+import { analyzeReactFile } from './file.js'
+
+const fixturesDir = path.resolve(import.meta.dirname, '../../../test/fixtures')
+const reactModeDir = path.join(fixturesDir, 'react-mode', 'src')
+
+const appShellFixture = loadReactFileFixture('AppShell.tsx', {
+  './components/DynamicHost': path.join(
+    reactModeDir,
+    'components',
+    'DynamicHost.tsx',
+  ),
+  './components/Panel': path.join(reactModeDir, 'components', 'Panel.tsx'),
+  './hooks/useFeature': path.join(reactModeDir, 'hooks', 'useFeature.ts'),
+})
+
+const styledEntryFixture = loadReactFileFixture('styled-entry.tsx', {
+  './components/BaseCard': path.join(
+    reactModeDir,
+    'components',
+    'BaseCard.tsx',
+  ),
+  './components/Link': path.join(reactModeDir, 'components', 'Link.tsx'),
+})
+
+describe('analyzeReactFile', () => {
+  bench('AppShell symbol analysis', () => {
+    analyzeReactFile(
+      appShellFixture.program,
+      appShellFixture.filePath,
+      appShellFixture.sourceText,
+      false,
+      appShellFixture.sourceDependencies,
+      false,
+    )
+  })
+
+  bench('styled entry with builtin tracking', () => {
+    analyzeReactFile(
+      styledEntryFixture.program,
+      styledEntryFixture.filePath,
+      styledEntryFixture.sourceText,
+      true,
+      styledEntryFixture.sourceDependencies,
+      true,
+    )
+  })
+})
+
+function loadReactFileFixture(
+  relativePath: string,
+  sourceDependencies: Readonly<Record<string, string>>,
+): {
+  readonly filePath: string
+  readonly sourceText: string
+  readonly program: ReturnType<typeof parseSync>['program']
+  readonly sourceDependencies: ReadonlyMap<string, string>
+} {
+  const filePath = path.join(reactModeDir, relativePath)
+  const sourceText = fs.readFileSync(filePath, 'utf8')
+  const program = parseSync(filePath, sourceText, {
+    astType: 'ts',
+    sourceType: 'unambiguous',
+  }).program
+
+  return {
+    filePath,
+    sourceText,
+    program,
+    sourceDependencies: new Map(Object.entries(sourceDependencies)),
+  }
+}

--- a/src/analyzers/react/index.spec.ts
+++ b/src/analyzers/react/index.spec.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { analyzeDependenciesForEntries } from '../import/index.js'
+import { analyzeReactUsageDiff } from './diff.js'
 import { analyzeReactFile } from './file.js'
 import { analyzeReactUsage } from './index.js'
 
@@ -22,6 +23,10 @@ afterEach(() => {
 describe('analyzeReactUsage', () => {
   it('exports a callable react analyzer', () => {
     expect(analyzeReactUsage).toBeTypeOf('function')
+  })
+
+  it('exports a callable react diff analyzer', () => {
+    expect(analyzeReactUsageDiff).toBeTypeOf('function')
   })
 
   it('builds dependencies once for multi-entry analysis', () => {

--- a/src/app/args.ts
+++ b/src/app/args.ts
@@ -24,6 +24,7 @@ export interface DepsCliOptions extends BaseCliOptions {
 export interface ReactCliOptions extends BaseCliOptions {
   readonly command: 'react'
   readonly entryFile: string | undefined
+  readonly diff: string | undefined
   readonly filter: ReactUsageFilter
   readonly nextjs: boolean
   readonly includeBuiltins: boolean

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -92,6 +92,10 @@ class CliMain {
     cli
       .command('react [entry-file]', 'Analyze React usage from an entry file.')
       .usage('react [entry-file] [options]')
+      .option(
+        '--diff <git-ref-or-range>',
+        'Show only React tree changes relative to a Git revision or range.',
+      )
       .option('--cwd <path>', 'Working directory used for relative paths.')
       .option(
         '--config <path>',
@@ -182,6 +186,7 @@ interface ParsedImportCliOptions extends ParsedBaseCliOptions {
 }
 
 interface ParsedReactCliOptions extends ParsedBaseCliOptions {
+  readonly diff?: string
   readonly filter?: string
   readonly nextjs?: boolean
   readonly builtin?: boolean
@@ -227,6 +232,7 @@ function normalizeReactCliOptions(
   return {
     command: 'react',
     entryFile: resolveReactEntryFile(entryFile, options.nextjs),
+    diff: options.diff,
     cwd: options.cwd,
     configPath: options.config,
     expandWorkspaces: options.workspaces !== false,

--- a/src/app/react-entry-files.spec.ts
+++ b/src/app/react-entry-files.spec.ts
@@ -23,6 +23,7 @@ describe('react entry file helpers', () => {
       resolveReactEntryFiles({
         command: 'react',
         entryFile: 'src/main.tsx',
+        diff: undefined,
         cwd: '/repo',
         configPath: undefined,
         expandWorkspaces: true,
@@ -40,6 +41,7 @@ describe('react entry file helpers', () => {
       resolveReactEntryFiles({
         command: 'react',
         entryFile: undefined,
+        diff: undefined,
         cwd: '/repo',
         configPath: undefined,
         expandWorkspaces: true,

--- a/src/commands/react.ts
+++ b/src/commands/react.ts
@@ -1,31 +1,51 @@
+import { analyzeReactUsageDiff } from '../analyzers/react/diff.js'
 import { analyzeReactUsage } from '../analyzers/react/index.js'
 import type { ReactCliOptions } from '../app/args.js'
 import { resolveReactEntryFiles } from '../app/react-entry-files.js'
-import { printReactUsageTree } from '../output/ascii/react.js'
-import { graphToSerializableReactTree } from '../output/json/react.js'
+import {
+  printReactUsageDiffTree,
+  printReactUsageTree,
+} from '../output/ascii/react.js'
+import {
+  diffGraphToSerializableReactTree,
+  graphToSerializableReactTree,
+} from '../output/json/react.js'
 import type { AnalyzeOptions } from '../types/analyze-options.js'
+import type { ReactUsageDiffGraph } from '../types/react-usage-diff-graph.js'
 import type { ReactUsageFilter } from '../types/react-usage-filter.js'
 import type { ReactUsageGraph } from '../types/react-usage-graph.js'
 import { BaseCommand } from './base.js'
 
 export class ReactCommand extends BaseCommand<
-  ReactUsageGraph,
+  ReactUsageGraph | ReactUsageDiffGraph,
   ReactCliOptions
 > {
-  protected analyze(): ReactUsageGraph {
+  protected analyze(): ReactUsageGraph | ReactUsageDiffGraph {
+    if (this.options.diff !== undefined) {
+      return analyzeReactUsageDiff(this.options)
+    }
+
     return analyzeReactUsage(
       resolveReactEntryFiles(this.options),
       this.getAnalyzeOptions(),
     )
   }
 
-  protected serialize(graph: ReactUsageGraph): object {
+  protected serialize(graph: ReactUsageGraph | ReactUsageDiffGraph): object {
+    if (isReactUsageDiffGraph(graph)) {
+      return diffGraphToSerializableReactTree(graph)
+    }
+
     return graphToSerializableReactTree(graph, {
       filter: this.getFilter(),
     })
   }
 
-  protected render(graph: ReactUsageGraph): string {
+  protected render(graph: ReactUsageGraph | ReactUsageDiffGraph): string {
+    if (isReactUsageDiffGraph(graph)) {
+      return printReactUsageDiffTree(graph)
+    }
+
     return printReactUsageTree(graph, {
       cwd: this.options.cwd ?? graph.cwd,
       filter: this.getFilter(),
@@ -42,4 +62,10 @@ export class ReactCommand extends BaseCommand<
   private getFilter(): ReactUsageFilter {
     return this.options.filter
   }
+}
+
+function isReactUsageDiffGraph(
+  graph: ReactUsageGraph | ReactUsageDiffGraph,
+): graph is ReactUsageDiffGraph {
+  return 'kind' in graph && graph.kind === 'react-usage-diff'
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { analyzePackageDependencyDiff } from './analyzers/deps/diff.js'
 export { analyzePackageDependencies } from './analyzers/deps/index.js'
 export { analyzeDependencies } from './analyzers/import/index.js'
+export { analyzeReactUsageDiff } from './analyzers/react/diff.js'
 export { analyzeReactUsage } from './analyzers/react/index.js'
 export {
   getFilteredUsages,
@@ -12,13 +13,19 @@ export {
   printPackageDependencyTree,
 } from './output/ascii/deps.js'
 export { printDependencyTree } from './output/ascii/import.js'
-export { printReactUsageTree } from './output/ascii/react.js'
+export {
+  printReactUsageDiffTree,
+  printReactUsageTree,
+} from './output/ascii/react.js'
 export {
   diffGraphToSerializablePackageTree,
   graphToSerializablePackageTree,
 } from './output/json/deps.js'
 export { graphToSerializableTree } from './output/json/import.js'
-export { graphToSerializableReactTree } from './output/json/react.js'
+export {
+  diffGraphToSerializableReactTree,
+  graphToSerializableReactTree,
+} from './output/json/react.js'
 export type { AnalyzeOptions } from './types/analyze-options.js'
 export type { ColorMode } from './types/color-mode.js'
 export type { DependencyEdge } from './types/dependency-edge.js'
@@ -35,6 +42,10 @@ export type { PrintPackageTreeOptions } from './types/print-package-tree-options
 export type { PrintReactTreeOptions } from './types/print-react-tree-options.js'
 export type { PrintTreeOptions } from './types/print-tree-options.js'
 export type { ReactSymbolKind } from './types/react-symbol-kind.js'
+export type { ReactUsageDiffEdge } from './types/react-usage-diff-edge.js'
+export type { ReactUsageDiffEntry } from './types/react-usage-diff-entry.js'
+export type { ReactUsageDiffGraph } from './types/react-usage-diff-graph.js'
+export type { ReactUsageDiffNode } from './types/react-usage-diff-node.js'
 export type { ReactUsageEdge } from './types/react-usage-edge.js'
 export type { ReactUsageEdgeKind } from './types/react-usage-edge-kind.js'
 export type { ReactUsageEntry } from './types/react-usage-entry.js'

--- a/src/output/ascii/react.spec.ts
+++ b/src/output/ascii/react.spec.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { printReactUsageTree } from './react.js'
+import { printReactUsageDiffTree, printReactUsageTree } from './react.js'
 
 describe('ascii react output', () => {
   it('exports the react usage tree printer', () => {
     expect(printReactUsageTree).toBeTypeOf('function')
+    expect(printReactUsageDiffTree).toBeTypeOf('function')
   })
 })

--- a/src/output/ascii/react.ts
+++ b/src/output/ascii/react.ts
@@ -5,12 +5,17 @@ import {
 } from '../../analyzers/react/queries.js'
 import {
   colorizeMuted,
+  colorizePackageDiff,
   colorizeReactLabel,
   formatReactSymbolLabel,
   formatReactSymbolName,
   resolveColorSupport,
 } from '../../color.js'
 import type { PrintReactTreeOptions } from '../../types/print-react-tree-options.js'
+import type { ReactUsageDiffEdge } from '../../types/react-usage-diff-edge.js'
+import type { ReactUsageDiffEntry } from '../../types/react-usage-diff-entry.js'
+import type { ReactUsageDiffGraph } from '../../types/react-usage-diff-graph.js'
+import type { ReactUsageDiffNode } from '../../types/react-usage-diff-node.js'
 import type { ReactUsageEdge } from '../../types/react-usage-edge.js'
 import type { ReactUsageEntry } from '../../types/react-usage-entry.js'
 import type { ReactUsageGraph } from '../../types/react-usage-graph.js'
@@ -60,6 +65,45 @@ export function printReactUsageTree(
     })
 
     if (index < roots.length - 1) {
+      lines.push('')
+    }
+  })
+
+  return lines.join('\n')
+}
+
+export function printReactUsageDiffTree(
+  graph: ReactUsageDiffGraph,
+  options: PrintReactTreeOptions = {},
+): string {
+  const color = resolveColorSupport(options.color)
+
+  if (graph.entries.length > 0) {
+    return renderReactDiffEntries(graph.entries, color)
+  }
+
+  if (graph.roots.length === 0) {
+    return 'No React changes found.'
+  }
+
+  const lines: string[] = []
+
+  graph.roots.forEach((root, index) => {
+    lines.push(
+      formatDiffLine(root.change, formatReactDiffNodeLabel(root, color), color),
+    )
+    root.usages.forEach((usage, usageIndex) => {
+      lines.push(
+        ...renderDiffUsage(
+          usage,
+          color,
+          '',
+          usageIndex === root.usages.length - 1,
+        ),
+      )
+    })
+
+    if (index < graph.roots.length - 1) {
       lines.push('')
     }
   })
@@ -181,4 +225,220 @@ function formatReactEntryLabel(entry: ReactUsageEntry, cwd: string): string {
 
 function formatReactNodeFilePath(node: ReactUsageNode, cwd: string): string {
   return node.kind === 'builtin' ? 'html' : toDisplayPath(node.filePath, cwd)
+}
+
+function renderReactDiffEntries(
+  entries: readonly ReactUsageDiffEntry[],
+  color: boolean,
+): string {
+  const lines: string[] = []
+
+  entries.forEach((entry, index) => {
+    lines.push(
+      formatDiffLine(
+        resolveVisibleEntryChange(entry),
+        formatReactDiffEntryLabel(entry),
+        color,
+      ),
+    )
+    lines.push(
+      formatDiffLine(
+        entry.node.change,
+        formatReactDiffNodeLabel(
+          entry.node,
+          color,
+          entry.beforeReferenceName,
+          entry.afterReferenceName,
+        ),
+        color,
+      ),
+    )
+
+    entry.node.usages.forEach((usage, usageIndex) => {
+      lines.push(
+        ...renderDiffUsage(
+          usage,
+          color,
+          '',
+          usageIndex === entry.node.usages.length - 1,
+        ),
+      )
+    })
+
+    if (index < entries.length - 1) {
+      lines.push('')
+    }
+  })
+
+  return lines.join('\n')
+}
+
+function renderDiffUsage(
+  usage: ReactUsageDiffEdge,
+  color: boolean,
+  prefix: string,
+  isLast: boolean,
+): string[] {
+  const branch = `${prefix}${isLast ? '└─ ' : '├─ '}`
+  const line = `${branch}${formatDiffLine(
+    resolveVisibleEdgeChange(usage),
+    formatReactDiffNodeLabel(
+      usage.node,
+      color,
+      usage.beforeReferenceName,
+      usage.afterReferenceName,
+    ),
+    color,
+  )}`
+
+  if (usage.node.circular === true) {
+    return [`${line} (circular)`]
+  }
+
+  const childLines = [line]
+  const nextPrefix = `${prefix}${isLast ? '   ' : '│  '}`
+
+  usage.node.usages.forEach((childUsage, index) => {
+    childLines.push(
+      ...renderDiffUsage(
+        childUsage,
+        color,
+        nextPrefix,
+        index === usage.node.usages.length - 1,
+      ),
+    )
+  })
+
+  return childLines
+}
+
+function formatReactDiffEntryLabel(entry: ReactUsageDiffEntry): string {
+  const beforeLocation =
+    entry.beforeFilePath === undefined ||
+    entry.beforeLine === undefined ||
+    entry.beforeColumn === undefined
+      ? undefined
+      : `${entry.beforeFilePath}:${entry.beforeLine}:${entry.beforeColumn}`
+  const afterLocation =
+    entry.afterFilePath === undefined ||
+    entry.afterLine === undefined ||
+    entry.afterColumn === undefined
+      ? undefined
+      : `${entry.afterFilePath}:${entry.afterLine}:${entry.afterColumn}`
+
+  if (
+    entry.change === 'changed' &&
+    beforeLocation !== undefined &&
+    afterLocation !== undefined
+  ) {
+    return `${beforeLocation} -> ${afterLocation}`
+  }
+
+  return afterLocation ?? beforeLocation ?? entry.referenceName
+}
+
+function formatReactDiffNodeLabel(
+  node: ReactUsageDiffNode,
+  color: boolean,
+  beforeReferenceName?: string,
+  afterReferenceName?: string,
+): string {
+  const label = formatReactDiffSymbolLabel(
+    node.name,
+    node.symbolKind,
+    color,
+    beforeReferenceName,
+    afterReferenceName,
+  )
+
+  return `${label} (${node.filePath})`
+}
+
+function formatReactDiffSymbolLabel(
+  name: string,
+  kind: ReactUsageDiffNode['symbolKind'],
+  color: boolean,
+  beforeReferenceName?: string,
+  afterReferenceName?: string,
+): string {
+  const referenceNames = [beforeReferenceName, afterReferenceName].filter(
+    (referenceName): referenceName is string => referenceName !== undefined,
+  )
+  const hasMeaningfulAlias = referenceNames.some(
+    (referenceName) => referenceName !== name,
+  )
+
+  if (!hasMeaningfulAlias) {
+    return formatReactSymbolLabel(name, kind, color)
+  }
+
+  const aliasText = formatReactDiffAlias(
+    name,
+    beforeReferenceName,
+    afterReferenceName,
+  )
+
+  return `${colorizeReactLabel(formatReactSymbolName(name, kind), kind, color)} ${colorizeMuted(
+    aliasText,
+    color,
+  )} ${colorizeReactLabel(`[${kind}]`, kind, color)}`
+}
+
+function formatReactDiffAlias(
+  name: string,
+  beforeReferenceName?: string,
+  afterReferenceName?: string,
+): string {
+  if (
+    beforeReferenceName !== undefined &&
+    afterReferenceName !== undefined &&
+    beforeReferenceName !== afterReferenceName
+  ) {
+    return `as ${beforeReferenceName} -> ${afterReferenceName}`
+  }
+
+  const currentReferenceName = afterReferenceName ?? beforeReferenceName
+  if (currentReferenceName === undefined || currentReferenceName === name) {
+    return 'as self'
+  }
+
+  return `as ${currentReferenceName}`
+}
+
+function resolveVisibleEntryChange(
+  entry: ReactUsageDiffEntry,
+): 'added' | 'removed' | 'changed' | 'unchanged' {
+  return entry.change === 'unchanged' ? entry.node.change : entry.change
+}
+
+function resolveVisibleEdgeChange(
+  usage: ReactUsageDiffEdge,
+): 'added' | 'removed' | 'changed' | 'unchanged' {
+  return usage.change === 'unchanged' ? usage.node.change : usage.change
+}
+
+function formatDiffLine(
+  change: 'added' | 'removed' | 'changed' | 'unchanged',
+  text: string,
+  color: boolean,
+): string {
+  if (change === 'unchanged') {
+    return text
+  }
+
+  return colorizePackageDiff(`${toDiffMarker(change)} ${text}`, change, color)
+}
+
+function toDiffMarker(
+  change: 'added' | 'removed' | 'changed',
+): '+' | '-' | '~' {
+  if (change === 'added') {
+    return '+'
+  }
+
+  if (change === 'removed') {
+    return '-'
+  }
+
+  return '~'
 }

--- a/src/output/json/react.spec.ts
+++ b/src/output/json/react.spec.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { graphToSerializableReactTree } from './react.js'
+import {
+  diffGraphToSerializableReactTree,
+  graphToSerializableReactTree,
+} from './react.js'
 
 describe('json react output', () => {
   it('exports the react tree serializer', () => {
     expect(graphToSerializableReactTree).toBeTypeOf('function')
+    expect(diffGraphToSerializableReactTree).toBeTypeOf('function')
   })
 })

--- a/src/output/json/react.ts
+++ b/src/output/json/react.ts
@@ -3,6 +3,10 @@ import {
   getReactUsageEntries,
   getReactUsageRoots,
 } from '../../analyzers/react/queries.js'
+import type { ReactUsageDiffEdge } from '../../types/react-usage-diff-edge.js'
+import type { ReactUsageDiffEntry } from '../../types/react-usage-diff-entry.js'
+import type { ReactUsageDiffGraph } from '../../types/react-usage-diff-graph.js'
+import type { ReactUsageDiffNode } from '../../types/react-usage-diff-node.js'
 import type { ReactUsageEntry } from '../../types/react-usage-entry.js'
 import type { ReactUsageFilter } from '../../types/react-usage-filter.js'
 import type { ReactUsageGraph } from '../../types/react-usage-graph.js'
@@ -58,6 +62,16 @@ export function graphToSerializableReactTree(
       serializeReactUsageEntry(entry, graph, filter),
     ),
     roots,
+  }
+}
+
+export function diffGraphToSerializableReactTree(
+  graph: ReactUsageDiffGraph,
+): object {
+  return {
+    kind: graph.kind,
+    entries: graph.entries.map((entry) => serializeReactDiffEntry(entry)),
+    roots: graph.roots.map((root) => serializeReactDiffNode(root)),
   }
 }
 
@@ -129,4 +143,70 @@ function formatReactNodeFilePath(
   cwd: string,
 ): string {
   return kind === 'builtin' ? 'html' : toDisplayPath(filePath, cwd)
+}
+
+function serializeReactDiffNode(node: ReactUsageDiffNode): object {
+  return {
+    id: node.id,
+    name: node.name,
+    symbolKind: node.symbolKind,
+    ...(node.circular === true ? { circular: true } : {}),
+    filePath: node.filePath,
+    change: node.change,
+    exportNames: node.exportNames,
+    ...(node.beforeExportNames === undefined
+      ? {}
+      : { beforeExportNames: node.beforeExportNames }),
+    ...(node.afterExportNames === undefined
+      ? {}
+      : { afterExportNames: node.afterExportNames }),
+    usages: node.usages.map((usage) => serializeReactDiffEdge(usage)),
+  }
+}
+
+function serializeReactDiffEdge(usage: ReactUsageDiffEdge): object {
+  return {
+    key: usage.key,
+    kind: usage.kind,
+    change: usage.change,
+    targetId: usage.targetId,
+    referenceName: usage.referenceName,
+    ...(usage.beforeReferenceName === undefined
+      ? {}
+      : { beforeReferenceName: usage.beforeReferenceName }),
+    ...(usage.afterReferenceName === undefined
+      ? {}
+      : { afterReferenceName: usage.afterReferenceName }),
+    node: serializeReactDiffNode(usage.node),
+  }
+}
+
+function serializeReactDiffEntry(entry: ReactUsageDiffEntry): object {
+  return {
+    key: entry.key,
+    change: entry.change,
+    targetId: entry.targetId,
+    referenceName: entry.referenceName,
+    ...(entry.beforeReferenceName === undefined
+      ? {}
+      : { beforeReferenceName: entry.beforeReferenceName }),
+    ...(entry.afterReferenceName === undefined
+      ? {}
+      : { afterReferenceName: entry.afterReferenceName }),
+    ...(entry.beforeFilePath === undefined
+      ? {}
+      : { beforeFilePath: entry.beforeFilePath }),
+    ...(entry.beforeLine === undefined ? {} : { beforeLine: entry.beforeLine }),
+    ...(entry.beforeColumn === undefined
+      ? {}
+      : { beforeColumn: entry.beforeColumn }),
+    ...(entry.afterFilePath === undefined
+      ? {}
+      : { afterFilePath: entry.afterFilePath }),
+    ...(entry.afterLine === undefined ? {} : { afterLine: entry.afterLine }),
+    ...(entry.afterColumn === undefined
+      ? {}
+      : { afterColumn: entry.afterColumn }),
+    node: serializeReactDiffNode(entry.node),
+  }
 }

--- a/src/types/react-usage-diff-edge.ts
+++ b/src/types/react-usage-diff-edge.ts
@@ -1,0 +1,14 @@
+import type { PackageDependencyChangeKind } from './package-dependency-change-kind.js'
+import type { ReactUsageDiffNode } from './react-usage-diff-node.js'
+import type { ReactUsageEdgeKind } from './react-usage-edge-kind.js'
+
+export interface ReactUsageDiffEdge {
+  readonly key: string
+  readonly kind: ReactUsageEdgeKind
+  readonly change: PackageDependencyChangeKind
+  readonly targetId: string
+  readonly referenceName: string
+  readonly beforeReferenceName?: string
+  readonly afterReferenceName?: string
+  readonly node: ReactUsageDiffNode
+}

--- a/src/types/react-usage-diff-entry.ts
+++ b/src/types/react-usage-diff-entry.ts
@@ -1,0 +1,18 @@
+import type { PackageDependencyChangeKind } from './package-dependency-change-kind.js'
+import type { ReactUsageDiffNode } from './react-usage-diff-node.js'
+
+export interface ReactUsageDiffEntry {
+  readonly key: string
+  readonly change: PackageDependencyChangeKind
+  readonly targetId: string
+  readonly referenceName: string
+  readonly beforeReferenceName?: string
+  readonly afterReferenceName?: string
+  readonly beforeFilePath?: string
+  readonly beforeLine?: number
+  readonly beforeColumn?: number
+  readonly afterFilePath?: string
+  readonly afterLine?: number
+  readonly afterColumn?: number
+  readonly node: ReactUsageDiffNode
+}

--- a/src/types/react-usage-diff-graph.ts
+++ b/src/types/react-usage-diff-graph.ts
@@ -1,0 +1,10 @@
+import type { ReactUsageDiffEntry } from './react-usage-diff-entry.js'
+import type { ReactUsageDiffNode } from './react-usage-diff-node.js'
+
+export interface ReactUsageDiffGraph {
+  readonly kind: 'react-usage-diff'
+  readonly repositoryRoot: string
+  readonly cwd: string
+  readonly entries: readonly ReactUsageDiffEntry[]
+  readonly roots: readonly ReactUsageDiffNode[]
+}

--- a/src/types/react-usage-diff-node.ts
+++ b/src/types/react-usage-diff-node.ts
@@ -1,0 +1,16 @@
+import type { PackageDependencyChangeKind } from './package-dependency-change-kind.js'
+import type { ReactSymbolKind } from './react-symbol-kind.js'
+import type { ReactUsageDiffEdge } from './react-usage-diff-edge.js'
+
+export interface ReactUsageDiffNode {
+  readonly id: string
+  readonly name: string
+  readonly symbolKind: ReactSymbolKind
+  readonly circular?: boolean
+  readonly filePath: string
+  readonly change: PackageDependencyChangeKind
+  readonly exportNames: readonly string[]
+  readonly beforeExportNames?: readonly string[]
+  readonly afterExportNames?: readonly string[]
+  readonly usages: readonly ReactUsageDiffEdge[]
+}


### PR DESCRIPTION
## Summary

- Add Git-based React usage diff analysis with ASCII/JSON output support.
- Add benchmark coverage for React diff, React file analysis, import graph building, and deps diff paths.
- Expand tests and README coverage for the new diff mode and git buffer handling.

## Related Issue

N/A

## Validation

- [ ] `pnpm run check`
- [x] Commits follow Conventional Commits
- [ ] Branch name follows `codex/issue-<number>-<slug>`
- [x] This PR will be Squash Merged into `dev`

## Notes

- Verified with `pnpm run typecheck`, React/deps e2e tests, and targeted Vitest bench runs.